### PR TITLE
CI/CD: pydpf-post tests running on master branch of pydpf-core repository

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
         python setup.py bdist_wheel
         export WHEELNAME=`ls dist/*.whl`
         echo ${WHEELNAME}
-        pip install ${WHEELNAME}
+        pip install ${WHEELNAME} --no-deps
         cd tests
         python -c "from ansys.dpf import post; print(post.Report())"
       displayName: Install ansys-dpf-post

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -101,6 +101,13 @@ jobs:
 
     - script: |
         pip install -r requirements_build.txt
+        
+        cd ${BUILD_BINARIESDIRECTORY}
+        git clone https://github.com/pyansys/pydpf-core
+        cd pydpf-core
+        pip install .
+        
+        cd ${SYSTEM_DEFAULTWORKINGDIRECTORY}
         python setup.py bdist_wheel
         export WHEELNAME=`ls dist/*.whl`
         echo ${WHEELNAME}

--- a/.ci/templates/prepare-environment-windows.yml
+++ b/.ci/templates/prepare-environment-windows.yml
@@ -35,7 +35,7 @@ steps:
         python setup.py bdist_wheel
         FOR /F %%a in ('dir /s/b dist\*.whl') do SET WHEELPATH=%%a
         ECHO %WHEELPATH% 
-        pip install %WHEELPATH%
+        pip install %WHEELPATH% --no-deps
         cd tests
         python -c "from ansys.dpf import post; print(post.Report(gpu=False))"           
       

--- a/.ci/templates/prepare-environment-windows.yml
+++ b/.ci/templates/prepare-environment-windows.yml
@@ -37,6 +37,7 @@ steps:
         ECHO %WHEELPATH% 
         pip install %WHEELPATH% --no-deps
         cd tests
+        pip install scooby
         python -c "from ansys.dpf import post; print(post.Report(gpu=False))"           
       
       displayName: Install ansys-dpf-post

--- a/.ci/templates/prepare-environment-windows.yml
+++ b/.ci/templates/prepare-environment-windows.yml
@@ -25,6 +25,13 @@ steps:
         
     - script: |
         pip install -r requirements_build.txt
+        
+        cd $(Build.BinariesDirectory)
+        git clone https://github.com/pyansys/pydpf-core
+        cd pydpf-core
+        pip install .
+        
+        cd $(System.DefaultWorkingDirectory)
         python setup.py bdist_wheel
         FOR /F %%a in ('dir /s/b dist\*.whl') do SET WHEELPATH=%%a
         ECHO %WHEELPATH% 

--- a/ansys/dpf/post/_version.py
+++ b/ansys/dpf/post/_version.py
@@ -1,6 +1,6 @@
 """Version for ansys-dpf-post"""
 # major, minor, patch
-version_info = 0, 2, 0
+version_info = 0, 2, 'dev3'
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))

--- a/ansys/dpf/post/misc.py
+++ b/ansys/dpf/post/misc.py
@@ -1,4 +1,15 @@
-from scooby import Report as ScoobyReport
+# ANSYS CPython Workbench environment may not have scooby installed.
+try:
+    from scooby import Report as ScoobyReport
+except ImportError:
+
+    class ScoobyReport:
+        """Placeholder for Scooby report."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "Install `scooby` with `pip install scooby` to use " "this feature"
+            )
 
 
 class Report(ScoobyReport):

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,7 @@
 pypandoc>=1.5.0
 matplotlib
+vtk<9.1.0
+pyvista
 imageio>=2.5.0
 imageio-ffmpeg
 Sphinx

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,6 @@
 pytest
 pytest-cov
 pytest-rerunfailures
+matplotlib==3.2
+vtk<9.1.0
+pyvista>=0.24.0


### PR DESCRIPTION
While running the CI/CD, pydpf-post unit tests are now ran using the core from the pydpf-core  repository (master branch). This will allow continuous integration if changes are required from core to update the ansys-dpf-post, without having to re-publish a new ansys-dpf-core package. 

**Next step**
Once #52 is merged, this branch needs to use the .ci/templates/prepare-environment-linux.yml template in the Linux testing job. 