### PR TITLE
Remove _plot_chart docstring example AND restrain protobuf

### DIFF
--- a/ansys/dpf/post/result_data.py
+++ b/ansys/dpf/post/result_data.py
@@ -351,16 +351,6 @@ class ResultData:
         A time_scoping keyword must be used to select all the
         time_steps of the result.
 
-        Examples
-        --------
-        >>> from ansys.dpf import post
-        >>> from ansys.dpf.post import examples
-        >>> solution = post.load_solution(examples.msup_transient)
-        >>> tscope = list(range(1, len(solution.time_freq_support.time_frequencies) + 1))
-        >>> stress = solution.stress(location='Nodal', time_scoping=tscope)
-        >>> s = stress.tensor
-        >>> pl = s._plot_chart()
-
         """
         self._evaluate_result()
         # tfq = self._evaluator._model.metadata.time_freq_support

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from io import open as io_open
 from setuptools import setup
 
-install_requires = ["ansys.dpf.core>=0.3.0", "scooby"]
+install_requires = ["ansys.dpf.core>=0.3.0", "scooby", "protobuf<=3.20.1"]
 
 
 # Get version from version info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,14 @@ import os
 
 import pytest
 import pyvista as pv
+import matplotlib as mpl
 
 from ansys.dpf import core
 from ansys.dpf.post import examples
 
 # enable off_screen plotting to avoid test interruption
 pv.OFF_SCREEN = True
-
+mpl.use("Agg")
 
 # currently running dpf on docker.  Used for testing on CI
 running_docker = os.environ.get("DPF_DOCKER", False)


### PR DESCRIPTION
Removes the dosctring example for _plot_chart in result_data.py as it does not take the global PyVista env in account and freezes the pipelines.
Also cherrypicks the commit for restraining protobuf to 3.* since it also prevents the pipelines from running.