### PR TITLE
Improve TypeHints

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,14 +47,13 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
     "numpydoc",
     "sphinx.ext.todo",
     "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",
 ]
-autodoc_typehints = "description"
 
 # Intersphinx mapping
 intersphinx_mapping = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,12 +44,12 @@ release = version = __version__
 # ones.
 extensions = [
     "notfound.extension",
-    "sphinx.ext.autodoc.typehints",
-    "sphinx.ext.napoleon",
-    "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.autodoc.typehints",
+    "sphinx.ext.napoleon",
+    "numpydoc",
     "sphinx.ext.todo",
     "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,8 @@ release = version = __version__
 # ones.
 extensions = [
     "notfound.extension",
+    "sphinx.ext.autodoc.typehints",
+    "sphinx.ext.napoleon",
     "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -52,6 +54,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",
 ]
+autodoc_typehints = "description"
 
 # Intersphinx mapping
 intersphinx_mapping = {

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -11,3 +11,4 @@ sphinx-notfound-page==0.8.3
 sphinx-copybutton==0.5.0
 sphinx-gallery==0.11.1
 ansys_sphinx_theme==0.5.2
+sphinx-autodoc-typehints==1.19.3

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -11,4 +11,4 @@ sphinx-notfound-page==0.8.3
 sphinx-copybutton==0.5.0
 sphinx-gallery==0.11.1
 ansys_sphinx_theme==0.5.2
-sphinx-autodoc-typehints==1.19.3
+sphinx-autodoc-typehints


### PR DESCRIPTION
Resolves #160. 

@PProfizi, note that the extensions are different in conf.py files from dpf-post and dpf-core. I was tempted to add all extensions from dpf-core to dpf-post, but in dpf-post we have 2 that are missing in dpf-core (notfound.extension and sphinx.ext.autosummary). I do not know if this is worth an issue and try to unify the extensions criterion. Thoughts?