### PR TITLE
Bump to 0.2.6.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-dpf-post"
-version = "0.2.6dev0"
+version = "0.2.6.dev0"
 description = "DPF-Post Python library."
 readme = "README.md"
 requires-python = ">=3.7.*,<4.0"


### PR DESCRIPTION
Instead of 0.2.6dev0, to be coherent with PyPI notation.