### PR TITLE
CI: fix mother branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
   upload_dev_docs:
     name: "Upload dev documentation"
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [docs]
     steps:


### PR DESCRIPTION
Use "master" instead of "main" for checking whether or not deploying documentation.