### PR TITLE
FIX: doc artifacts location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: documentation-html
-          path: doc/build/html
+          path: docs/build/html
           retention-days: 7
 
   upload_dev_docs:


### PR DESCRIPTION
Points to "docs" instead of "doc".