### PR TITLE
FIX: missing CNAME env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
   PACKAGE_NAME: ansys-dpf-post
   MODULE: post
   ANSYS_VERSION: 231
+  DOCUMENTATION_CNAME: 'post.docs.pyansys.com'
 
 jobs:
   style:


### PR DESCRIPTION
Adds missing environment variable indicating the CNAME for the documentation website.