### PR TITLE
Force doc style check with Vale before building the doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,15 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
 
+  docs-style:
+    name: "Check doc style"
+    uses: ./.github/workflows/docs-style.yml
+    secrets: inherit
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    needs: [docs-style]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
 
-  docs-style:
+  doc-style:
     name: "Check doc style"
     uses: ./.github/workflows/docs-style.yml
     secrets: inherit
@@ -155,7 +155,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    needs: [docs-style]
+    needs: [doc-style]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -2,6 +2,7 @@
 name: Documentation Style Check
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/docs/source/api/result_data.rst
+++ b/docs/source/api/result_data.rst
@@ -5,7 +5,7 @@
 ********************
 
 The :class:`ResultData <ansys.dpf.post.result_data.ResultData>` class is
-created using the :class:`Result <ansys.dpf.core.results.Result>` class.  The ``Result``
+created using the :class:`Result <ansys.dpf.core.results.Result>` class. The ``Result``
 class provides access to the result values contained in the ``Result`` object.
 
 This example shows how to access ``displacement`` result values:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,7 +74,7 @@ scripts.
 
 **Easy to use**
 
-The PyDPF-Post API automates the use of DPF's chained operators to make
+The PyDPF-Post API automates the use of chained DPF operators to make
 postprocessing easier. The PyDPF-Post documentation describes how you can
 use operators to compute results. This allows you to build your own custom,
 low-level scripts to enable fast postprocessing of potentially multi-gigabyte


### PR DESCRIPTION
Vale had been integrated to the repository but only within a manually triggerable workflow.
This PR calls this workflow in the regular CI as a check step before building the documentation.
https://vale.sh/docs/vale-cli/overview/

Install Vale on Windows using choco (also explains how to install chocolatey):
https://docsy-site.netlify.app/docs/vale/install-vale/
Also install Sphinx using choco (required to treat .rst files):
`choco install sphinx`
Edit: does not seem to work in all cases, local usage TBD

How to integrate it to PyCharm as a tool to run before commiting:
https://vale.sh/docs/integrations/jetbrains/