### PR TITLE
Add get_data_by_id method in DataObject

### DIFF
--- a/src/ansys/dpf/post/data_object.py
+++ b/src/ansys/dpf/post/data_object.py
@@ -123,6 +123,23 @@ class DataObject:
         """
         return self._fc[-1].data
 
+    def get_data_by_id(self):
+        """Retrieve data together with its ID information.
+
+        Parameters
+        ----------
+        TODO
+
+        Returns
+        -------
+        TODO
+
+        Examples
+        --------
+        TODO
+
+        """
+
     def plot(self, **kwargs):
         """Plot the result."""
         self._fc[-1].plot(**kwargs)

--- a/tests/test_data_object.py
+++ b/tests/test_data_object.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from ansys.dpf import post
+
+
+def test_get_data_by_id(allkindofcomplexity):
+    simulation = post.load_simulation(allkindofcomplexity)
+    disp = simulation.displacement()
+    # Request all IDs
+    data, ids = disp.get_data_by_id()
+    assert len(data) == len(ids)
+    # Request a few ID numbers
+    data, ids = disp.get_data_by_id(get_ids=[1, 50, 100])
+    assert len(data) == len(ids)
+    assert (ids == np.array([1, 50, 100])).all()
+    # Request some IDs that are not available
+    data, ids = disp.get_data_by_id(get_ids=[1, 50, 100, -1])
+    assert len(data) == len(ids)
+    assert (ids == np.array([1, 50, 100])).all()


### PR DESCRIPTION
Fix #229.

This PR proposes the implementation of the ``get_data_by_id()`` method of ``DataObject``.

@rlagha, I was also thinking to use the ``as_array()`` method here, instead of ``get_data_by_id()``. I assume most users will want the data with its ID info when getting an array, so maybe we could just use ``as_array()``.

The output will be two ndarrays with the data and ids for all the fields in the ``DataObject``. The first entry of each array is one field. For instance, to get the "Z" component of the displacement of the first field, the user would do:

```py
data, ids = simulation.displacement().get_data_by_id()
z_disp_first_field = data[0][3]
```