### PR TITLE
Implement HarmonicMechanicalSimulation results

### DIFF
--- a/examples/00-Overview/02-get_data_from_static_simulation.py
+++ b/examples/00-Overview/02-get_data_from_static_simulation.py
@@ -10,10 +10,10 @@ The available results can be listed to see what results can be retrieved.
 ###############################################################################
 # Imports and loading simulation
 # ------------------------------
-import ansys.dpf.post as dpf
+from ansys.dpf import post
 from ansys.dpf.post import examples
 
-simulation = dpf.load_simulation(examples.static_rst)
+simulation = post.load_simulation(examples.static_rst)
 print(simulation)
 
 ###############################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
     {name = "PyAnsys developers", email = "pyansys.support@ansys.com"},
 ]
 dependencies = [
-    "ansys.dpf.core @ git+https://git@github.com/pyansys/pydpf-core.git",
+    "ansys.dpf.core",
     "scooby",
 ]
 classifiers = [

--- a/src/ansys/dpf/post/common.py
+++ b/src/ansys/dpf/post/common.py
@@ -1,7 +1,7 @@
 """Module containing the common tools for a better usage of the DPF-Post module."""
 
+from ansys.dpf.post.harmonic_mechanical_simulation import HarmonicMechanicalSimulation
 from ansys.dpf.post.modal_mechanical_simulation import ModalMechanicalSimulation
-from ansys.dpf.post.simulation import HarmonicMechanicalSimulation
 from ansys.dpf.post.static_mechanical_simulation import StaticMechanicalSimulation
 from ansys.dpf.post.transient_mechanical_simulation import TransientMechanicalSimulation
 

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -1,0 +1,478 @@
+"""Module containing the ``HarmonicMechanicalSimulation`` class."""
+from typing import List, Tuple, Union
+import warnings
+
+from ansys.dpf import core
+from ansys.dpf.post.data_object import DataObject
+from ansys.dpf.post.selection import Selection
+from ansys.dpf.post.simulation import MechanicalSimulation, ResultCategory
+
+
+class HarmonicMechanicalSimulation(MechanicalSimulation):
+    """Provides methods for mechanical harmonic simulations."""
+
+    def _get_result(
+        self,
+        base_name: str,
+        location: str,
+        category: ResultCategory,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        amplitude: bool = False,
+        sweeping_phase: Union[float, None] = None,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `modes` are mutually
+        exclusive.
+        If none of the above is given, only the first mode will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+         Args:
+            base_name:
+                Base name for the requested result.
+            location:
+                Location requested.
+            category:
+                Type of result requested. See the :class:`ResultCategory` class.
+            components:
+                Components to get results for.
+            norm:
+                Whether to return the norm of the results.
+            amplitude:
+                Whether to return the amplitude of the result.
+            sweeping_phase:
+                Sweeping phase value to extract result for. If a single `float` value is given, it
+                must be in degrees. Mutually exclusive with `amplitude`.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                List of sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                List of load steps to get results for.
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        # Build the targeted spatial and time scoping
+        tot = (
+            (set_ids is not None)
+            + (all_sets is True)
+            + (frequencies is not None)
+            + (load_steps is not None)
+            + (selection is not None)
+        )
+        if tot > 1:
+            raise ValueError(
+                "Arguments all_sets, selection, set_ids, frequencies, "
+                "and load_steps are mutually exclusive."
+            )
+        elif tot == 0:
+            set_ids = 1
+
+        tot = (
+            (node_ids is not None)
+            + (element_ids is not None)
+            + (named_selections is not None)
+            + (selection is not None)
+        )
+        if tot > 1:
+            raise ValueError(
+                "Arguments selection, named_selections, element_ids, "
+                "and node_ids are mutually exclusive"
+            )
+
+        selection = self._build_selection(
+            selection=selection,
+            set_ids=set_ids,
+            times=frequencies,
+            load_steps=load_steps,
+            all_sets=all_sets,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+            location=location,
+        )
+
+        # Build the list of requested results
+        if category in [ResultCategory.scalar, ResultCategory.equivalent]:
+            # A scalar or equivalent result has no components
+            to_extract = None
+            columns = [base_name]
+        elif category in [ResultCategory.vector, ResultCategory.matrix]:
+            # A matrix or vector result can have components selected
+            to_extract, columns = self._build_components_from_components(
+                base_name=base_name, category=category, components=components
+            )
+        elif category == ResultCategory.principal:
+            # A principal type of result can have components selected
+            to_extract, columns = self._build_components_from_principal(
+                base_name=base_name, components=components
+            )
+        else:
+            raise ValueError(f"'{category}' is not a valid category value.")
+
+        # Initialize a workflow
+        wf = core.Workflow(server=self._model._server)
+        wf.progress_bar = False
+
+        # Instantiate the main result operator
+        result_op = self._build_result_operator(
+            name=base_name,
+            location=location,
+        )
+        # Its output is selected as future workflow output for now
+        out = result_op.outputs.fields_container
+        # Its inputs are selected as workflow inputs for merging with selection workflows
+        wf.set_input_name("time_scoping", result_op.inputs.time_scoping)
+        wf.set_input_name("mesh_scoping", result_op.inputs.mesh_scoping)
+
+        wf.connect_with(
+            selection.time_freq_selection._selection,
+            output_input_names=("scoping", "time_scoping"),
+        )
+        wf.connect_with(
+            selection.spatial_selection._selection,
+            output_input_names=("scoping", "mesh_scoping"),
+        )
+
+        # Connect data_sources and streams_container inputs of selection if necessary
+        if "streams" in wf.input_names:
+            wf.connect("streams", self._model.metadata.streams_provider)
+        if "data_sources" in wf.input_names:
+            wf.connect("data_sources", self._model.metadata.data_sources)
+
+        # Add a step to compute principal invariants if result is principal
+        if category == ResultCategory.principal:
+            # Instantiate the required operator
+            principal_op = self._model.operator(name="eig_values_fc")
+            principal_op.connect(0, out)
+            wf.add_operator(operator=principal_op)
+            # Set as future output of the workflow
+            out = principal_op.outputs.fields_container
+
+        # Add a step to compute equivalent if result is equivalent
+        elif category == ResultCategory.equivalent:
+            # If a stress result, use one operator
+            if base_name[0] == "S":
+                equivalent_op = self._model.operator(name="segalmaneqv_fc")
+            # If a strain result, use another
+            elif base_name[0] == "E":
+                equivalent_op = self._model.operator(name="eqv_fc")
+            # Throw otherwise
+            else:
+                raise ValueError(
+                    f"Category {ResultCategory.equivalent} "
+                    "is only available for stress or strain results."
+                )
+            equivalent_op.connect(0, out)
+            wf.add_operator(operator=equivalent_op)
+            # Set as future output of the workflow
+            out = equivalent_op.outputs.fields_container
+
+        # Add an optional component selection step if result is vector, matrix, or principal
+        if (
+            category
+            in [ResultCategory.vector, ResultCategory.matrix, ResultCategory.principal]
+        ) and (to_extract is not None):
+            # Instantiate a component selector operator
+            extract_op = self._model.operator(name="component_selector_fc")
+            # Feed it the current workflow output
+            extract_op.connect(0, out)
+            # Feed it the requested components
+            extract_op.connect(1, to_extract)
+            wf.add_operator(operator=extract_op)
+            # Set as future output of the workflow
+            out = extract_op.outputs.fields_container
+
+        # Add an optional norm operation if requested
+        if norm:
+            norm_op = self._model.operator(name="norm_fc")
+            norm_op.connect(0, out)
+            wf.add_operator(operator=norm_op)
+            out = norm_op.outputs.fields_container
+
+        # Set the workflow output
+        wf.set_output_name("out", out)
+        # Evaluate  the workflow
+        fc = wf.get_output("out", core.types.fields_container)
+
+        # Test for empty results
+        if (len(fc) == 0) or all([len(f) == 0 for f in fc]):
+            warnings.warn(
+                message=f"Returned Dataframe with columns {columns} is empty.",
+                category=UserWarning,
+            )
+        # Return the result wrapped in a DPF_Dataframe
+        return DataObject(
+            fields_container=fc,
+            columns=columns,
+            mesh_scoping=None,
+        )
+
+    def displacement(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        amplitude: bool = False,
+        sweeping_phase: Union[float, None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract displacement results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements whose nodes to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            amplitude:
+                Whether to return the amplitude of the result.
+            sweeping_phase:
+                Sweeping phase value to extract result for. If a single `float` value is given, it
+                must be in degrees. Mutually exclusive with `amplitude`.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                List of load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="U",
+            location=core.locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            norm=norm,
+            amplitude=amplitude,
+            sweeping_phase=sweeping_phase,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def velocity(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        amplitude: bool = False,
+        sweeping_phase: Union[float, None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract velocity results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements whose nodes to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            amplitude:
+                Whether to return the amplitude of the result.
+            sweeping_phase:
+                Sweeping phase value to extract result for. If a single `float` value is given, it
+                must be in degrees. Mutually exclusive with `amplitude`.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                List of load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="V",
+            location=core.locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            norm=norm,
+            amplitude=amplitude,
+            sweeping_phase=sweeping_phase,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def acceleration(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        amplitude: bool = False,
+        sweeping_phase: Union[float, None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract acceleration results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements whose nodes to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            amplitude:
+                Whether to return the amplitude of the result.
+            sweeping_phase:
+                Sweeping phase value to extract result for. If a single `float` value is given, it
+                must be in degrees. Mutually exclusive with `amplitude`.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                List of load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="A",
+            location=core.locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            norm=norm,
+            amplitude=amplitude,
+            sweeping_phase=sweeping_phase,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -3,6 +3,7 @@ from typing import List, Tuple, Union
 import warnings
 
 from ansys.dpf import core
+from ansys.dpf.post import locations
 from ansys.dpf.post.data_object import DataObject
 from ansys.dpf.post.selection import Selection
 from ansys.dpf.post.simulation import MechanicalSimulation, ResultCategory
@@ -308,7 +309,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="U",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -388,7 +389,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="V",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -468,7 +469,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="A",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -95,8 +95,6 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 "Arguments all_sets, selection, set_ids, frequencies, "
                 "and load_steps are mutually exclusive."
             )
-        elif tot == 0:
-            set_ids = 1
 
         tot = (
             (node_ids is not None)

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -54,10 +54,10 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             norm:
                 Whether to return the norm of the results.
             amplitude:
-                Whether to return the amplitude of the result.
+                Whether to return the amplitude of the result. Overrides `sweeping_phase`.
             sweeping_phase:
                 Sweeping phase value to extract result for. If a single `float` value is given, it
-                must be in degrees. Mutually exclusive with `amplitude`.
+                must be in degrees. Unused if `amplitude=True`.
             selection:
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
@@ -210,20 +210,6 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                     # Set as future output of the workflow
                     out = average_op.outputs.fields_container
 
-        # Add an optional sweeping phase operation if requested
-        if sweeping_phase is not None:
-            if isinstance(sweeping_phase, int):
-                sweeping_phase = float(sweeping_phase)
-            if not isinstance(sweeping_phase, float):
-                raise ValueError("Argument sweeping_phase must be a float.")
-            sweeping_op = self._model.operator(name="sweeping_phase_fc")
-            sweeping_op.connect(0, out)
-            sweeping_op.connect(2, sweeping_phase)
-            sweeping_op.connect(3, "degree")
-            sweeping_op.connect(4, False)
-            wf.add_operator(operator=sweeping_op)
-            out = sweeping_op.outputs.fields_container
-
         # Add an optional component selection step if result is vector, matrix, or principal
         if (
             category
@@ -242,14 +228,29 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             # Set as future output of the workflow
             out = extract_op.outputs.fields_container
 
-        # Add an optional amplitude operation if requested
-        if amplitude:
+        # Add an optional sweeping phase or amplitude operation if requested
+        # (must be after comp_selector for U)
+        # (must be before norm operation for U)
+        if sweeping_phase is not None and not amplitude:
+            if isinstance(sweeping_phase, int):
+                sweeping_phase = float(sweeping_phase)
+            if not isinstance(sweeping_phase, float):
+                raise ValueError("Argument sweeping_phase must be a float.")
+            sweeping_op = self._model.operator(name="sweeping_phase_fc")
+            sweeping_op.connect(0, out)
+            sweeping_op.connect(2, sweeping_phase)
+            sweeping_op.connect(3, "degree")
+            sweeping_op.connect(4, False)
+            wf.add_operator(operator=sweeping_op)
+            out = sweeping_op.outputs.fields_container
+        elif amplitude:
             amplitude_op = self._model.operator(name="amplitude_fc")
             amplitude_op.connect(0, out)
             wf.add_operator(operator=amplitude_op)
             out = amplitude_op.outputs.fields_container
 
         # Add an optional norm operation if requested
+        # (must be after sweeping_phase for U)
         if norm:
             norm_op = self._model.operator(name="norm_fc")
             norm_op.connect(0, out)
@@ -287,8 +288,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
-        amplitude: bool = False,
-        sweeping_phase: Union[float, None] = 0.0,
+        # amplitude: bool = False,
+        # sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[
@@ -319,11 +320,6 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 and their respective equivalents 1, 2, 3.
             norm:
                 Whether to return the norm of the results.
-            amplitude:
-                Whether to return the amplitude of the result.
-            sweeping_phase:
-                Sweeping phase value to extract result for. If a single `float` value is given, it
-                must be in degrees. Mutually exclusive with `amplitude`.
             set_ids:
                 Sets to get results for.
                 A set is defined as a unique combination of {time, load step, sub-step}.
@@ -348,8 +344,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             category=ResultCategory.vector,
             components=components,
             norm=norm,
-            amplitude=amplitude,
-            sweeping_phase=sweeping_phase,
+            amplitude=False,
+            sweeping_phase=None,
             selection=selection,
             frequencies=frequencies,
             set_ids=set_ids,
@@ -367,8 +363,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
-        amplitude: bool = False,
-        sweeping_phase: Union[float, None] = 0.0,
+        # amplitude: bool = False,
+        # sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[
@@ -399,11 +395,6 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 and their respective equivalents 1, 2, 3.
             norm:
                 Whether to return the norm of the results.
-            amplitude:
-                Whether to return the amplitude of the result.
-            sweeping_phase:
-                Sweeping phase value to extract result for. If a single `float` value is given, it
-                must be in degrees. Mutually exclusive with `amplitude`.
             set_ids:
                 Sets to get results for.
                 A set is defined as a unique combination of {time, load step, sub-step}.
@@ -428,8 +419,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             category=ResultCategory.vector,
             components=components,
             norm=norm,
-            amplitude=amplitude,
-            sweeping_phase=sweeping_phase,
+            amplitude=False,
+            sweeping_phase=None,
             selection=selection,
             frequencies=frequencies,
             set_ids=set_ids,
@@ -447,8 +438,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
-        amplitude: bool = False,
-        sweeping_phase: Union[float, None] = 0.0,
+        # amplitude: bool = False,
+        # sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[
@@ -479,11 +470,6 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 and their respective equivalents 1, 2, 3.
             norm:
                 Whether to return the norm of the results.
-            amplitude:
-                Whether to return the amplitude of the result.
-            sweeping_phase:
-                Sweeping phase value to extract result for. If a single `float` value is given, it
-                must be in degrees. Mutually exclusive with `amplitude`.
             set_ids:
                 Sets to get results for.
                 A set is defined as a unique combination of {time, load step, sub-step}.
@@ -508,8 +494,2125 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             category=ResultCategory.vector,
             components=components,
             norm=norm,
-            amplitude=amplitude,
-            sweeping_phase=sweeping_phase,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=location,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.elemental,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.nodal,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_principal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[List[str], List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal principal stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=location,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_principal_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[List[str], List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental principal stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.elemental,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_principal_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[List[str], List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal principal stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs pf elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.nodal,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_eqv_von_mises(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal equivalent Von Mises stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=location,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_eqv_von_mises_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental equivalent Von Mises stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.elemental,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def stress_eqv_von_mises_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal equivalent Von Mises stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="S",
+            location=locations.nodal,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=location,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.nodal,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract stress results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z", "XX", "XY",
+                "XZ", and their respective equivalents 1, 2, 3, 4, 5, 6.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.elemental,
+            category=ResultCategory.matrix,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_principal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal principal elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=location,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_principal_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal principal elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs pf elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.nodal,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_principal_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental principal elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are: 1, 2, and 3.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.elemental,
+            category=ResultCategory.principal,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_eqv_von_mises(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal equivalent Von Mises elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=location,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_eqv_von_mises_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental equivalent Von Mises elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.elemental,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elastic_strain_eqv_von_mises_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal equivalent Von Mises elastic strain results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EPEL",
+            location=locations.nodal,
+            category=ResultCategory.equivalent,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def reaction_force(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract reaction force results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="RF",
+            location=locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elemental_volume(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental volume results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="ENG_VOL",
+            location=locations.elemental,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def elemental_mass(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental mass results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="ElementalMass",
+            location=locations.elemental,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_nodal_forces(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract element nodal forces results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="ENF",
+            location=location,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_nodal_forces_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract element nodal forces nodal results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="ENF",
+            location=locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_nodal_forces_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract element nodal forces elemental results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="ENF",
+            location=locations.elemental,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def nodal_force(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal force results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="F",
+            location=locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def nodal_moment(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        components: Union[str, List[str], int, List[int], None] = None,
+        norm: bool = False,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal moment results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            components:
+                Components to get results for. Available components are "X", "Y", "Z",
+                and their respective equivalents 1, 2, 3.
+            norm:
+                Whether to return the norm of the results.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="M",
+            location=locations.nodal,
+            category=ResultCategory.vector,
+            components=components,
+            amplitude=False,
+            sweeping_phase=None,
+            norm=norm,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_centroids(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract element centroids results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="centroids",
+            location=locations.elemental,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def thickness(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract element thickness results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="thickness",
+            location=locations.elemental,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_orientations(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+        location: Union[locations, str] = locations.elemental_nodal,
+    ) -> DataObject:
+        """Extract elemental nodal element orientations results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+            location:
+                Location to extract results at. Available locations are listed in `locations`
+                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
+                gives results with a value for every node at each element. "Elemental" gives results
+                with one value for each element. "Nodal" gives results with one value for each node.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EUL",
+            location=location,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=node_ids,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_orientations_elemental(
+        self,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract elemental element orientations results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EUL",
+            location=locations.elemental,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
+            selection=selection,
+            frequencies=frequencies,
+            set_ids=set_ids,
+            all_sets=all_sets,
+            load_steps=load_steps,
+            node_ids=None,
+            element_ids=element_ids,
+            named_selections=named_selections,
+        )
+
+    def element_orientations_nodal(
+        self,
+        node_ids: Union[List[int], None] = None,
+        element_ids: Union[List[int], None] = None,
+        frequencies: Union[float, List[float], None] = None,
+        set_ids: Union[int, List[int], None] = None,
+        all_sets: bool = False,
+        load_steps: Union[
+            int, List[int], Tuple[int, Union[int, List[int]]], None
+        ] = None,
+        named_selections: Union[List[str], str, None] = None,
+        selection: Union[Selection, None] = None,
+    ) -> DataObject:
+        """Extract nodal element orientations results from the simulation.
+
+        Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `load_steps` are mutually
+        exclusive.
+        If none of the above is given, the last frequency will be returned.
+
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
+        exclusive.
+        If none of the above is given, results will be extracted for the whole mesh.
+
+        Args:
+            node_ids:
+                List of IDs of nodes to get results for.
+            element_ids:
+                List of IDs of elements to get results for.
+            frequencies:
+                Frequency value or list of frequency values to get results for.
+            set_ids:
+                Sets to get results for.
+                A set is defined as a unique combination of {time, load step, sub-step}.
+            all_sets:
+                Whether to get results for all sets.
+            load_steps:
+                Load steps to get results for.
+            named_selections:
+                Named selection or list of named selections to get results for.
+            selection:
+                Selection to get results for.
+                A Selection defines both spatial and time-like criteria for filtering.
+
+        Returns
+        -------
+            Returns a :class:`ansys.dpf.post.data_object.DataObject` instance.
+
+        """
+        return self._get_result(
+            base_name="EUL",
+            location=locations.nodal,
+            category=ResultCategory.scalar,
+            components=None,
+            amplitude=False,
+            sweeping_phase=None,
             selection=selection,
             frequencies=frequencies,
             set_ids=set_ids,

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -20,7 +20,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
         amplitude: bool = False,
-        sweeping_phase: Union[float, None] = None,
+        sweeping_phase: Union[float, None] = 0.0,
         node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
@@ -144,6 +144,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
 
         if category == ResultCategory.equivalent and base_name[0] == "E":
             force_elemental_nodal = True
+        # elif sweeping_phase is not None:
+        #     force_elemental_nodal = True
         else:
             force_elemental_nodal = False
 
@@ -207,6 +209,20 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                     wf.add_operator(operator=average_op)
                     # Set as future output of the workflow
                     out = average_op.outputs.fields_container
+
+        # Add an optional sweeping phase operation if requested
+        if sweeping_phase is not None:
+            if isinstance(sweeping_phase, int):
+                sweeping_phase = float(sweeping_phase)
+            if not isinstance(sweeping_phase, float):
+                raise ValueError("Argument sweeping_phase must be a float.")
+            sweeping_op = self._model.operator(name="sweeping_phase_fc")
+            sweeping_op.connect(0, out)
+            sweeping_op.connect(2, sweeping_phase)
+            sweeping_op.connect(3, "degree")
+            sweeping_op.connect(4, False)
+            wf.add_operator(operator=sweeping_op)
+            out = sweeping_op.outputs.fields_container
 
         # Add an optional component selection step if result is vector, matrix, or principal
         if (
@@ -272,7 +288,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
         amplitude: bool = False,
-        sweeping_phase: Union[float, None] = None,
+        sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[
@@ -352,7 +368,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
         amplitude: bool = False,
-        sweeping_phase: Union[float, None] = None,
+        sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[
@@ -432,7 +448,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         components: Union[str, List[str], int, List[int], None] = None,
         norm: bool = False,
         amplitude: bool = False,
-        sweeping_phase: Union[float, None] = None,
+        sweeping_phase: Union[float, None] = 0.0,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
         load_steps: Union[

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -32,7 +32,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
     ) -> DataObject:
-        """Extract stress results from the simulation.
+        """Extract results from the simulation.
 
         Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `modes` are mutually
         exclusive.

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -75,7 +75,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             node_ids:
                 List of IDs of nodes to get results for.
             element_ids:
@@ -332,7 +334,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -407,7 +411,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -482,7 +488,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -553,7 +561,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -627,7 +637,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -696,7 +708,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -765,7 +779,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -838,7 +854,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -906,7 +924,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -972,7 +992,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1042,7 +1064,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1107,7 +1131,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1177,7 +1203,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1254,7 +1282,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1320,7 +1350,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1389,7 +1421,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1465,7 +1499,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1530,7 +1566,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1596,7 +1634,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1666,7 +1706,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1731,7 +1773,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1803,7 +1847,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1866,7 +1912,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1928,7 +1976,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2001,7 +2051,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2082,7 +2134,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2152,7 +2206,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2225,7 +2281,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2298,7 +2356,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2361,7 +2421,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2423,7 +2485,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2489,7 +2553,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2559,7 +2625,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2624,7 +2692,9 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -46,7 +46,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             base_name:
                 Base name for the requested result.
             location:
-                Location requested.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             category:
                 Type of result requested. See the :class:`ResultCategory` class.
             components:
@@ -554,10 +560,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -763,10 +772,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -967,10 +979,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1169,10 +1184,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1378,10 +1396,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1582,10 +1603,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1984,10 +2008,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2469,10 +2496,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -210,7 +210,7 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
                     # Set as future output of the workflow
                     out = average_op.outputs.fields_container
 
-        # Add an optional component selection step if result is vector, matrix, or principal
+        # Add an optional component selection step if result is vector, or matrix
         if (
             category
             in [

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -212,6 +212,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
             # Set as future output of the workflow
             out = extract_op.outputs.fields_container
 
+        # Add an optional amplitude operation if requested
+        if amplitude:
+            amplitude_op = self._model.operator(name="amplitude_fc")
+            amplitude_op.connect(0, out)
+            wf.add_operator(operator=amplitude_op)
+            out = amplitude_op.outputs.fields_container
+
         # Add an optional norm operation if requested
         if norm:
             norm_op = self._model.operator(name="norm_fc")

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -305,6 +305,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def stress(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -321,11 +322,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
-        Args:
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -366,7 +369,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -500,6 +503,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def stress_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[List[str], List[int], None] = None,
@@ -516,11 +520,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -560,7 +566,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -692,6 +698,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def stress_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -707,11 +714,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -749,7 +758,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -875,6 +884,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -891,11 +901,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
-        Args:
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -936,7 +948,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1070,6 +1082,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1086,11 +1099,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -1130,7 +1145,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1262,6 +1277,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -1277,11 +1293,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -1319,7 +1337,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1445,6 +1463,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def plastic_state_variable(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -1460,11 +1479,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -1502,7 +1523,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1628,6 +1649,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1644,11 +1666,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
-        Args:
+         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -1689,7 +1713,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1823,6 +1847,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1839,11 +1864,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -1883,7 +1910,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2015,6 +2042,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_eqv(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -2030,11 +2058,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -2072,7 +2102,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2499,6 +2529,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def element_orientations(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -2514,11 +2545,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -2556,7 +2589,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2682,6 +2715,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def hydrostatic_pressure(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         modes: Union[int, List[int], None] = None,
@@ -2697,11 +2731,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -2739,7 +2775,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2865,6 +2901,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
 
     def element_nodal_forces(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         frequencies: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -2882,11 +2919,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the first mode will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
          Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             frequencies:
@@ -2930,7 +2969,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             modes=modes,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -28,7 +28,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
     ) -> DataObject:
-        """Extract stress results from the simulation.
+        """Extract results from the simulation.
 
         Arguments `selection`, `set_ids`, `all_sets`, `frequencies`, and `modes` are mutually
         exclusive.

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -42,7 +42,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             base_name:
                 Base name for the requested result.
             location:
-                Location requested.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             category:
                 Type of result requested. See the :class:`ResultCategory` class.
             components:
@@ -344,10 +350,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -541,10 +550,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -733,10 +745,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -923,10 +938,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -1120,10 +1138,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -1312,10 +1333,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -1498,10 +1522,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -1688,10 +1715,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -1885,10 +1915,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -2077,10 +2110,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -2564,10 +2600,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -2750,10 +2789,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.
@@ -2943,10 +2985,13 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             set_ids:
                 Sets to get results for. Equivalent to modes.
                 Common to all simulation types for easier scripting.

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -3,6 +3,7 @@ from typing import List, Union
 import warnings
 
 from ansys.dpf import core
+from ansys.dpf.post import locations
 from ansys.dpf.post.data_object import DataObject
 from ansys.dpf.post.selection import Selection
 from ansys.dpf.post.simulation import MechanicalSimulation, ResultCategory
@@ -178,9 +179,9 @@ class ModalMechanicalSimulation(MechanicalSimulation):
             # If a strain result, change the location now
             if force_elemental_nodal:
                 average_op = None
-                if location == core.locations.nodal:
+                if location == locations.nodal:
                     average_op = self._model.operator(name="to_nodal_fc")
-                elif location == core.locations.elemental:
+                elif location == locations.elemental:
                     average_op = self._model.operator(name="to_elemental_fc")
                 if average_op is not None:
                     average_op.connect(0, out)
@@ -288,7 +289,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="U",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -310,7 +311,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -340,7 +341,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -419,7 +420,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -484,7 +485,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -505,7 +506,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -534,7 +535,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -612,7 +613,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -676,7 +677,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -696,7 +697,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -723,7 +724,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -798,7 +799,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -859,7 +860,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -880,7 +881,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -910,7 +911,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -992,7 +993,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1054,7 +1055,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1075,7 +1076,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -1104,7 +1105,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1185,7 +1186,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1246,7 +1247,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1266,7 +1267,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -1293,7 +1294,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1368,7 +1369,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1429,7 +1430,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1449,7 +1450,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -1476,7 +1477,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1551,7 +1552,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1612,7 +1613,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1633,7 +1634,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -1663,7 +1664,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1745,7 +1746,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1807,7 +1808,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1828,7 +1829,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -1857,7 +1858,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1938,7 +1939,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1999,7 +2000,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2019,7 +2020,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -2046,7 +2047,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2124,7 +2125,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2182,7 +2183,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2250,7 +2251,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="RF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -2309,7 +2310,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_VOL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2367,7 +2368,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ElementalMass",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2425,7 +2426,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="centroids",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2483,7 +2484,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="thickness",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2503,7 +2504,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -2530,7 +2531,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2605,7 +2606,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2666,7 +2667,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2686,7 +2687,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -2713,7 +2714,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2791,7 +2792,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2849,7 +2850,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2871,7 +2872,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         modes: Union[int, List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
         set_ids: Union[int, List[int], None] = None,
         all_sets: bool = False,
     ) -> DataObject:
@@ -2903,7 +2904,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2989,7 +2990,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3055,7 +3056,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3124,7 +3125,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="F",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3193,7 +3194,7 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="M",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,

--- a/src/ansys/dpf/post/post_utility.py
+++ b/src/ansys/dpf/post/post_utility.py
@@ -212,7 +212,7 @@ def load_simulation(
     if simulation_type in [
         getattr(AvailableSimulationTypes, x) for x in vars(AvailableSimulationTypes)
     ]:
-        return simulation_type_str_to_class[simulation_type](data_sources, _model)
+        return simulation_type_str_to_class[simulation_type](data_sources)
     else:
         raise ValueError(
             f"Simulation type '{simulation_type}' is not a recognized simulation type."

--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -412,7 +412,7 @@ class MechanicalSimulation(Simulation, ABC):
         named_selections: Union[List[str], str, None] = None,
         element_ids: Union[List[int], None] = None,
         node_ids: Union[List[int], None] = None,
-        location: locations = locations.nodal,
+        location: Union[locations, str] = locations.nodal,
     ) -> Selection:
         tot = (
             (node_ids is not None)

--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -513,11 +513,3 @@ class MechanicalSimulation(Simulation, ABC):
                 time_freq_sets=[self.time_freq_support.n_sets]
             )
         return selection
-
-
-class HarmonicMechanicalSimulation(MechanicalSimulation):
-    """Provides methods for mechanical harmonic simulations."""
-
-    def _build_time_freq_scoping(self) -> core.time_freq_scoping_factory.Scoping:
-        """Generate a time_freq_scoping from input arguments."""
-        pass

--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -438,6 +438,11 @@ class MechanicalSimulation(Simulation, ABC):
             else:
                 selection.select_elements(elements=element_ids)
         elif node_ids:
+            if location != locations.nodal:
+                raise ValueError(
+                    "Argument 'node_ids' can only be used if 'location' "
+                    "is equal to 'post.locations.nodal'."
+                )
             selection.select_nodes(nodes=node_ids)
         # Create the TimeFreqSelection
         if all_sets:

--- a/src/ansys/dpf/post/simulation.py
+++ b/src/ansys/dpf/post/simulation.py
@@ -1,6 +1,7 @@
 """Module containing the ``Simulation`` class."""
 from abc import ABC
 from enum import Enum
+from os import PathLike
 import re
 from typing import List, Tuple, Union
 
@@ -393,9 +394,11 @@ class MechanicalSimulation(Simulation, ABC):
     This class provides common methods and properties for all mechanical type simulations.
     """
 
-    def __init__(self, data_sources: dpf.DataSources, model: dpf.Model):
+    def __init__(self, result_file: PathLike):
         """Instantiate a mechanical type simulation."""
-        super().__init__(data_sources, model)
+        model = dpf.Model(result_file)
+        data_sources = model.metadata.data_sources
+        super().__init__(data_sources=data_sources, model=model)
 
     def _build_selection(
         self,

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -68,7 +68,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             node_ids:
                 List of IDs of nodes to get results for.
             element_ids:
@@ -283,7 +285,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -352,7 +356,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -424,7 +430,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -491,7 +499,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -559,7 +569,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -630,7 +642,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -696,7 +710,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -760,7 +776,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -828,7 +846,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -891,7 +911,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -959,7 +981,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1034,7 +1058,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1098,7 +1124,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1165,7 +1193,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1239,7 +1269,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1302,7 +1334,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1366,7 +1400,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1434,7 +1470,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1497,7 +1535,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1561,7 +1601,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1629,7 +1671,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1692,7 +1736,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1760,7 +1806,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1835,7 +1883,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1899,7 +1949,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1966,7 +2018,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2040,7 +2094,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2103,7 +2159,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2167,7 +2225,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2238,7 +2298,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2298,7 +2360,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2366,7 +2430,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2441,7 +2507,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2505,7 +2573,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2572,7 +2642,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2646,7 +2718,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2709,7 +2783,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2773,7 +2849,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2844,7 +2922,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2904,7 +2984,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2974,7 +3056,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3038,7 +3122,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3098,7 +3184,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3158,7 +3246,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3218,7 +3308,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3278,7 +3370,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3342,7 +3436,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3410,7 +3506,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3473,7 +3571,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3533,7 +3633,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3593,7 +3695,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3653,7 +3757,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3713,7 +3819,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3777,7 +3885,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3840,7 +3950,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3900,7 +4012,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3964,7 +4078,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4035,7 +4151,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4095,7 +4213,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4166,7 +4286,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4245,7 +4367,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4313,7 +4437,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4384,7 +4510,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -4455,7 +4583,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -3,6 +3,7 @@ from typing import List, Tuple, Union
 import warnings
 
 from ansys.dpf import core
+from ansys.dpf.post import locations
 from ansys.dpf.post.data_object import DataObject
 from ansys.dpf.post.selection import Selection
 from ansys.dpf.post.simulation import MechanicalSimulation, ResultCategory
@@ -178,9 +179,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             # If a strain result, change the location now
             if force_elemental_nodal:
                 average_op = None
-                if location == core.locations.nodal:
+                if location == locations.nodal:
                     average_op = self._model.operator(name="to_nodal_fc")
-                elif location == core.locations.elemental:
+                elif location == locations.elemental:
                     average_op = self._model.operator(name="to_elemental_fc")
                 if average_op is not None:
                     average_op.connect(0, out)
@@ -290,7 +291,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="U",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -316,7 +317,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal stress results from the simulation.
 
@@ -349,7 +350,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -425,7 +426,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -492,7 +493,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -517,7 +518,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal stress results from the simulation.
 
@@ -549,7 +550,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -624,7 +625,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -690,7 +691,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -714,7 +715,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent Von Mises stress results from the simulation.
 
@@ -744,7 +745,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -816,7 +817,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -879,7 +880,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -904,7 +905,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract stress results from the simulation.
 
@@ -937,7 +938,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1016,7 +1017,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1080,7 +1081,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1105,7 +1106,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal elastic strain results from the simulation.
 
@@ -1137,7 +1138,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1215,7 +1216,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1278,7 +1279,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1302,7 +1303,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent Von Mises elastic strain results from the simulation.
 
@@ -1332,7 +1333,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1404,7 +1405,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1467,7 +1468,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1491,7 +1492,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal plastic state variable results from the simulation.
 
@@ -1521,7 +1522,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1593,7 +1594,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1656,7 +1657,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1681,7 +1682,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal plastic strain results from the simulation.
 
@@ -1714,7 +1715,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1793,7 +1794,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1857,7 +1858,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1882,7 +1883,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal plastic strain results from the simulation.
 
@@ -1914,7 +1915,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1992,7 +1993,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2055,7 +2056,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2079,7 +2080,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent plastic strain results from the simulation.
 
@@ -2109,7 +2110,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2184,7 +2185,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2244,7 +2245,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2269,7 +2270,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal creep strain results from the simulation.
 
@@ -2302,7 +2303,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2381,7 +2382,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -2445,7 +2446,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -2470,7 +2471,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal creep strain results from the simulation.
 
@@ -2502,7 +2503,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2580,7 +2581,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2643,7 +2644,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2667,7 +2668,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent creep strain results from the simulation.
 
@@ -2697,7 +2698,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2772,7 +2773,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2832,7 +2833,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ECR",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2902,7 +2903,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="RF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -2963,7 +2964,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_VOL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3023,7 +3024,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ElementalMass",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3083,7 +3084,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EHC",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3143,7 +3144,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="centroids",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3203,7 +3204,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="thickness",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3227,7 +3228,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal element orientations results from the simulation.
 
@@ -3257,7 +3258,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -3329,7 +3330,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3392,7 +3393,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3452,7 +3453,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_SE",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3512,7 +3513,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_AHO",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3572,7 +3573,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_TH",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3632,7 +3633,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_KE",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3656,7 +3657,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract hydrostatic pressure element nodal results from the simulation.
 
@@ -3756,7 +3757,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3816,7 +3817,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3840,7 +3841,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract structural temperature element nodal results from the simulation.
 
@@ -3870,7 +3871,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -3945,7 +3946,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="BFE",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -4005,7 +4006,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="BFE",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -4031,7 +4032,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract element nodal forces results from the simulation.
 
@@ -4066,7 +4067,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -4149,7 +4150,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -4217,7 +4218,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -4288,7 +4289,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="F",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -4359,7 +4360,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="M",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -30,7 +30,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         element_ids: Union[List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
     ) -> DataObject:
-        """Extract stress results from the simulation.
+        """Extract results from the simulation.
 
         Arguments `selection`, `set_ids`, `all_sets`, `times`, and `load_steps` are mutually
         exclusive.

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -44,7 +44,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             base_name:
                 Base name for the requested result.
             location:
-                Location requested.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             category:
                 Type of result requested. See the :class:`ResultCategory` class.
             components:
@@ -353,10 +359,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -557,10 +566,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -755,10 +767,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -951,10 +966,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1154,10 +1172,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1352,10 +1373,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1544,10 +1568,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1740,10 +1767,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1943,10 +1973,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2141,10 +2174,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2337,10 +2373,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2540,10 +2579,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2738,10 +2780,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -3304,10 +3349,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -3923,10 +3971,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -4122,10 +4173,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -307,6 +307,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def stress(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -330,6 +331,8 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -370,7 +373,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -508,6 +511,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def stress_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         components: Union[List[str], List[int], None] = None,
@@ -526,11 +530,14 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
+
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -570,7 +577,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -706,6 +713,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def stress_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -723,11 +731,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -765,7 +775,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -895,6 +905,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -913,11 +924,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -958,7 +971,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1096,6 +1109,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1114,11 +1128,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1158,7 +1174,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1294,6 +1310,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -1311,11 +1328,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1353,7 +1372,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1483,6 +1502,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def plastic_state_variable(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -1500,11 +1520,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1542,7 +1564,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1672,6 +1694,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1690,11 +1713,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1735,7 +1760,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1873,6 +1898,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1891,11 +1917,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1935,7 +1963,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2071,6 +2099,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_eqv(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -2088,11 +2117,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2130,7 +2161,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2260,6 +2291,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def creep_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -2278,11 +2310,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2323,7 +2357,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2461,6 +2495,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def creep_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -2479,11 +2514,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2523,7 +2560,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2659,6 +2696,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def creep_strain_eqv(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -2676,11 +2714,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2718,7 +2758,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2919,6 +2959,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def elemental_volume(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -2940,6 +2981,8 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2972,7 +3015,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3219,6 +3262,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def element_orientations(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -3236,11 +3280,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3278,7 +3324,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3648,6 +3694,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def hydrostatic_pressure(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -3665,11 +3712,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3702,7 +3751,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3832,6 +3881,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def structural_temperature(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -3849,11 +3899,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3891,7 +3943,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -4021,6 +4073,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
 
     def element_nodal_forces(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -4040,11 +4093,13 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -4088,7 +4143,7 @@ class StaticMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -69,7 +69,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                List of load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             node_ids:
                 List of IDs of nodes to get results for.
             element_ids:
@@ -288,7 +290,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -359,7 +363,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -430,7 +436,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -499,7 +507,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -571,7 +581,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -638,7 +650,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -705,7 +719,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -776,7 +792,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -842,7 +860,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -906,7 +926,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -974,7 +996,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1037,7 +1061,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1105,7 +1131,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1180,7 +1208,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1244,7 +1274,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1311,7 +1343,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1385,7 +1419,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1448,7 +1484,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1512,7 +1550,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1580,7 +1620,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1643,7 +1685,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1707,7 +1751,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1775,7 +1821,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1838,7 +1886,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1906,7 +1956,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -1981,7 +2033,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2045,7 +2099,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2112,7 +2168,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2186,7 +2244,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2249,7 +2309,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2313,7 +2375,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2384,7 +2448,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2444,7 +2510,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2514,7 +2582,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2575,7 +2645,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2635,7 +2707,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2695,7 +2769,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2755,7 +2831,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2815,7 +2893,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2879,7 +2959,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -2947,7 +3029,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3010,7 +3094,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3070,7 +3156,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3130,7 +3218,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3190,7 +3280,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3254,7 +3346,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3325,7 +3419,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3385,7 +3481,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3449,7 +3547,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3520,7 +3620,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3580,7 +3682,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3651,7 +3755,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3730,7 +3836,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3798,7 +3906,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3869,7 +3979,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:
@@ -3940,7 +4052,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             all_sets:
                 Whether to get results for all sets.
             load_steps:
-                Load steps to get results for.
+                Load step number or list of load step numbers to get results for.
+                One can specify sub-steps of a load step with a tuple of format:
+                (load-step, sub-step number or list of sub-step numbers).
             named_selections:
                 Named selection or list of named selections to get results for.
             selection:

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -454,6 +454,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def stress(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -472,11 +473,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             node_ids:
                 List of IDs of nodes to get results for.
             element_ids:
@@ -519,7 +522,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -657,6 +660,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def stress_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         components: Union[List[str], List[int], None] = None,
@@ -675,11 +679,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -719,7 +725,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -855,6 +861,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def stress_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -872,11 +879,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -914,7 +923,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1044,6 +1053,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1062,11 +1072,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1107,7 +1119,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1245,6 +1257,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1263,11 +1276,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1307,7 +1322,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1443,6 +1458,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def elastic_strain_eqv_von_mises(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -1460,11 +1476,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1502,7 +1520,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1632,6 +1650,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def plastic_state_variable(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -1649,11 +1668,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1691,7 +1712,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -1821,6 +1842,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -1839,11 +1861,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -1884,7 +1908,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2022,6 +2046,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_principal(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -2040,11 +2065,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2084,7 +2111,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2220,6 +2247,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def plastic_strain_eqv(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -2237,11 +2265,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2279,7 +2309,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -2780,6 +2810,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def element_orientations(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -2797,11 +2828,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -2839,7 +2872,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3149,6 +3182,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def hydrostatic_pressure(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -3166,11 +3200,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3208,7 +3244,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3338,6 +3374,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def structural_temperature(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         set_ids: Union[int, List[int], None] = None,
@@ -3355,11 +3392,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3397,7 +3436,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )
@@ -3527,6 +3566,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
 
     def element_nodal_forces(
         self,
+        node_ids: Union[List[int], None] = None,
         element_ids: Union[List[int], None] = None,
         times: Union[float, List[float], None] = None,
         components: Union[str, List[str], int, List[int], None] = None,
@@ -3546,11 +3586,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         exclusive.
         If none of the above is given, only the last result will be returned.
 
-        Arguments `selection`, `named_selections`, and `element_ids` are mutually
+        Arguments `selection`, `named_selections`, `element_ids`, and `node_ids` are mutually
         exclusive.
         If none of the above is given, results will be extracted for the whole mesh.
 
         Args:
+            node_ids:
+                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:
@@ -3594,7 +3636,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             set_ids=set_ids,
             all_sets=all_sets,
             load_steps=load_steps,
-            node_ids=None,
+            node_ids=node_ids,
             element_ids=element_ids,
             named_selections=named_selections,
         )

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -30,7 +30,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         element_ids: Union[List[int], None] = None,
         named_selections: Union[List[str], str, None] = None,
     ) -> DataObject:
-        """Extract stress results from the simulation.
+        """Extract results from the simulation.
 
         Arguments `selection`, `set_ids`, `all_sets`, `times`, and `load_steps` are mutually
         exclusive.

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -3,6 +3,7 @@ from typing import List, Tuple, Union
 import warnings
 
 from ansys.dpf import core
+from ansys.dpf.post import locations
 from ansys.dpf.post.data_object import DataObject
 from ansys.dpf.post.selection import Selection
 from ansys.dpf.post.simulation import MechanicalSimulation, ResultCategory
@@ -179,9 +180,9 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             # If a strain result, change the location now
             if force_elemental_nodal:
                 average_op = None
-                if location == core.locations.nodal:
+                if location == locations.nodal:
                     average_op = self._model.operator(name="to_nodal_fc")
-                elif location == core.locations.elemental:
+                elif location == locations.elemental:
                     average_op = self._model.operator(name="to_elemental_fc")
                 if average_op is not None:
                     average_op.connect(0, out)
@@ -295,7 +296,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="U",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -366,7 +367,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="V",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -437,7 +438,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="A",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -463,7 +464,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal stress results from the simulation.
 
@@ -498,7 +499,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -574,7 +575,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -641,7 +642,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -666,7 +667,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal stress results from the simulation.
 
@@ -698,7 +699,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -773,7 +774,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -839,7 +840,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -863,7 +864,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent Von Mises stress results from the simulation.
 
@@ -893,7 +894,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -965,7 +966,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1028,7 +1029,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="S",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1053,7 +1054,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract stress results from the simulation.
 
@@ -1086,7 +1087,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1165,7 +1166,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1229,7 +1230,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -1254,7 +1255,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal elastic strain results from the simulation.
 
@@ -1286,7 +1287,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1364,7 +1365,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1427,7 +1428,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -1451,7 +1452,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent Von Mises elastic strain results from the simulation.
 
@@ -1481,7 +1482,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1553,7 +1554,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1616,7 +1617,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPEL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -1640,7 +1641,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal plastic state variable results from the simulation.
 
@@ -1670,7 +1671,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1742,7 +1743,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1805,7 +1806,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_PSV",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -1830,7 +1831,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal plastic strain results from the simulation.
 
@@ -1863,7 +1864,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -1942,7 +1943,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -2006,7 +2007,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.matrix,
             components=components,
             selection=selection,
@@ -2031,7 +2032,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal principal plastic strain results from the simulation.
 
@@ -2063,7 +2064,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2141,7 +2142,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2204,7 +2205,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.principal,
             components=components,
             selection=selection,
@@ -2228,7 +2229,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal equivalent plastic strain results from the simulation.
 
@@ -2258,7 +2259,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2333,7 +2334,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2393,7 +2394,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EPPL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.equivalent,
             components=None,
             selection=selection,
@@ -2463,7 +2464,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="RF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -2524,7 +2525,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_VOL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2584,7 +2585,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ElementalMass",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2644,7 +2645,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EHC",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2704,7 +2705,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="centroids",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2764,7 +2765,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="thickness",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2788,7 +2789,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract elemental nodal element orientations results from the simulation.
 
@@ -2818,7 +2819,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -2890,7 +2891,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -2953,7 +2954,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="EUL",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3013,7 +3014,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_AHO",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3073,7 +3074,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_TH",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3133,7 +3134,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENG_KE",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3157,7 +3158,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract hydrostatic pressure element nodal results from the simulation.
 
@@ -3187,7 +3188,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -3262,7 +3263,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3322,7 +3323,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENL_HPRES",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components=None,
             selection=selection,
@@ -3346,7 +3347,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract structural temperature element nodal results from the simulation.
 
@@ -3376,7 +3377,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -3451,7 +3452,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="BFE",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3511,7 +3512,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="BFE",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.scalar,
             components="",
             selection=selection,
@@ -3537,7 +3538,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         ] = None,
         named_selections: Union[List[str], str, None] = None,
         selection: Union[Selection, None] = None,
-        location: Union[core.locations, str] = core.locations.elemental_nodal,
+        location: Union[locations, str] = locations.elemental_nodal,
     ) -> DataObject:
         """Extract element nodal forces results from the simulation.
 
@@ -3572,7 +3573,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `core.locations`
+                Location to extract results at. Available locations are listed in `locations`
                 and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
                 gives results with a value for every node at each element. "Elemental" gives results
                 with one value for each element. "Nodal" gives results with one value for each node.
@@ -3655,7 +3656,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3723,7 +3724,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="ENF",
-            location=core.locations.elemental,
+            location=locations.elemental,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3794,7 +3795,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="F",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,
@@ -3865,7 +3866,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         """
         return self._get_result(
             base_name="M",
-            location=core.locations.nodal,
+            location=locations.nodal,
             category=ResultCategory.vector,
             components=components,
             norm=norm,

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -44,7 +44,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
             base_name:
                 Base name for the requested result.
             location:
-                Location requested.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
             category:
                 Type of result requested. See the :class:`ResultCategory` class.
             components:
@@ -500,10 +506,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -703,10 +712,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -901,10 +913,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1097,10 +1112,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1300,10 +1318,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1498,10 +1519,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1690,10 +1714,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -1886,10 +1913,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2089,10 +2119,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2287,10 +2320,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -2850,10 +2886,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -3222,10 +3261,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -3414,10 +3456,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------
@@ -3613,10 +3658,13 @@ class TransientMechanicalSimulation(MechanicalSimulation):
                 Selection to get results for.
                 A Selection defines both spatial and time-like criteria for filtering.
             location:
-                Location to extract results at. Available locations are listed in `locations`
-                and are: "Nodal", "Elemental", and "ElementalNodal". The default "ElementalNodal"
-                gives results with a value for every node at each element. "Elemental" gives results
-                with one value for each element. "Nodal" gives results with one value for each node.
+                Location to extract results at. Available locations are listed in
+                class:`post.locations` and are: `post.locations.nodal`,
+                `post.locations.elemental`, and `post.locations.elemental_nodal`.
+                Using the default `post.locations.elemental_nodal` results in a value
+                for every node at each element. Similarly, using `post.locations.elemental`
+                gives results with one value for each element, while using `post.locations.nodal`
+                gives results with one value for each node.
 
         Returns
         -------

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -480,8 +480,6 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         Args:
             node_ids:
                 List of IDs of nodes to get results for.
-            node_ids:
-                List of IDs of nodes to get results for.
             element_ids:
                 List of IDs of elements to get results for.
             times:

--- a/tests/test_load_simulation.py
+++ b/tests/test_load_simulation.py
@@ -2,8 +2,8 @@ import pytest
 
 import ansys.dpf.post as dpf
 from ansys.dpf.post.common import AvailableSimulationTypes
+from ansys.dpf.post.harmonic_mechanical_simulation import HarmonicMechanicalSimulation
 from ansys.dpf.post.modal_mechanical_simulation import ModalMechanicalSimulation
-from ansys.dpf.post.simulation import HarmonicMechanicalSimulation
 from ansys.dpf.post.static_mechanical_simulation import StaticMechanicalSimulation
 from ansys.dpf.post.transient_mechanical_simulation import TransientMechanicalSimulation
 

--- a/tests/test_load_simulation.py
+++ b/tests/test_load_simulation.py
@@ -1,6 +1,6 @@
 import pytest
 
-import ansys.dpf.post as dpf
+from ansys.dpf import post
 from ansys.dpf.post.common import AvailableSimulationTypes
 from ansys.dpf.post.harmonic_mechanical_simulation import HarmonicMechanicalSimulation
 from ansys.dpf.post.modal_mechanical_simulation import ModalMechanicalSimulation
@@ -9,9 +9,9 @@ from ansys.dpf.post.transient_mechanical_simulation import TransientMechanicalSi
 
 
 def test_load_simulation_static_mechanical(simple_bar, complex_model):
-    simulation = dpf.load_simulation(data_sources=simple_bar)
+    simulation = post.load_simulation(data_sources=simple_bar)
     assert type(simulation) == StaticMechanicalSimulation
-    simulation = dpf.load_simulation(
+    simulation = post.load_simulation(
         data_sources=complex_model,
         simulation_type=AvailableSimulationTypes.static_mechanical,
     )
@@ -19,9 +19,9 @@ def test_load_simulation_static_mechanical(simple_bar, complex_model):
 
 
 def test_load_simulation_transient_mechanical(plate_msup, complex_model):
-    simulation = dpf.load_simulation(data_sources=plate_msup)
+    simulation = post.load_simulation(data_sources=plate_msup)
     assert type(simulation) == TransientMechanicalSimulation
-    simulation = dpf.load_simulation(
+    simulation = post.load_simulation(
         data_sources=complex_model,
         simulation_type=AvailableSimulationTypes.transient_mechanical,
     )
@@ -29,9 +29,9 @@ def test_load_simulation_transient_mechanical(plate_msup, complex_model):
 
 
 def test_load_simulation_modal_mechanical(modalallkindofcomplexity, complex_model):
-    simulation = dpf.load_simulation(data_sources=modalallkindofcomplexity)
+    simulation = post.load_simulation(data_sources=modalallkindofcomplexity)
     assert type(simulation) == ModalMechanicalSimulation
-    simulation = dpf.load_simulation(
+    simulation = post.load_simulation(
         data_sources=complex_model,
         simulation_type=AvailableSimulationTypes.transient_mechanical,
     )
@@ -39,9 +39,9 @@ def test_load_simulation_modal_mechanical(modalallkindofcomplexity, complex_mode
 
 
 def test_load_simulation_harmonic_mechanical(complex_model, simple_bar):
-    simulation = dpf.load_simulation(data_sources=complex_model)
+    simulation = post.load_simulation(data_sources=complex_model)
     assert type(simulation) == HarmonicMechanicalSimulation
-    simulation = dpf.load_simulation(
+    simulation = post.load_simulation(
         data_sources=simple_bar,
         simulation_type=AvailableSimulationTypes.harmonic_mechanical,
     )
@@ -50,7 +50,7 @@ def test_load_simulation_harmonic_mechanical(complex_model, simple_bar):
 
 def test_load_simulation_raise_simulation_type(simple_bar):
     with pytest.raises(ValueError, match="is not a recognized simulation type"):
-        _ = dpf.load_simulation(
+        _ = post.load_simulation(
             data_sources=simple_bar,
             simulation_type="test",
         )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1519,47 +1519,47 @@ class TestHarmonicMechanicalSimulation:
     #     assert field.data.shape == (3,)
     #     assert np.allclose(field.data, field_ref.data)
 
-    def test_velocity(self, harmonic_simulation):
-        print(harmonic_simulation)
-
-        result = harmonic_simulation.velocity(components=["X"], node_ids=[2, 3, 4])
-        assert len(result._fc) == 2
-        assert result._fc.get_time_scoping().ids == [1]
-        field = result._fc[0]
-        op = harmonic_simulation._model.operator("VX")
-        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
-            1, server=harmonic_simulation._model._server
-        )
-        op.connect(0, time_scoping)
-        mesh_scoping = core.mesh_scoping_factory.nodal_scoping(
-            [2, 3, 4], server=harmonic_simulation._model._server
-        )
-        op.connect(1, mesh_scoping)
-        field_ref = op.eval()[0]
-        assert field.component_count == 1
-        assert field.data.shape == (3,)
-        assert np.allclose(field.data, field_ref.data)
-
-    def test_acceleration(self, harmonic_simulation):
-        print(harmonic_simulation)
-
-        result = harmonic_simulation.acceleration(components=["X"], node_ids=[2, 3, 4])
-        assert len(result._fc) == 2
-        assert result._fc.get_time_scoping().ids == [1]
-        field = result._fc[0]
-        op = harmonic_simulation._model.operator("AX")
-        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
-            1, server=harmonic_simulation._model._server
-        )
-        op.connect(0, time_scoping)
-        mesh_scoping = core.mesh_scoping_factory.nodal_scoping(
-            [2, 3, 4], server=harmonic_simulation._model._server
-        )
-        op.connect(1, mesh_scoping)
-        field_ref = op.eval()[0]
-        assert field.component_count == 1
-        assert field.data.shape == (3,)
-        assert np.allclose(field.data, field_ref.data)
+    # def test_velocity(self, harmonic_simulation):
+    #     print(harmonic_simulation)
+    #
+    #     result = harmonic_simulation.velocity(components=["X"], node_ids=[2, 3, 4])
+    #     assert len(result._fc) == 2
+    #     assert result._fc.get_time_scoping().ids == [1]
+    #     field = result._fc[0]
+    #     op = harmonic_simulation._model.operator("VX")
+    #     time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+    #         1, server=harmonic_simulation._model._server
+    #     )
+    #     op.connect(0, time_scoping)
+    #     mesh_scoping = core.mesh_scoping_factory.nodal_scoping(
+    #         [2, 3, 4], server=harmonic_simulation._model._server
+    #     )
+    #     op.connect(1, mesh_scoping)
+    #     field_ref = op.eval()[0]
+    #     assert field.component_count == 1
+    #     assert field.data.shape == (3,)
+    #     assert np.allclose(field.data, field_ref.data)
+    #
+    # def test_acceleration(self, harmonic_simulation):
+    #     print(harmonic_simulation)
+    #
+    #     result = harmonic_simulation.acceleration(components=["X"], node_ids=[2, 3, 4])
+    #     assert len(result._fc) == 2
+    #     assert result._fc.get_time_scoping().ids == [1]
+    #     field = result._fc[0]
+    #     op = harmonic_simulation._model.operator("AX")
+    #     time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+    #         1, server=harmonic_simulation._model._server
+    #     )
+    #     op.connect(0, time_scoping)
+    #     mesh_scoping = core.mesh_scoping_factory.nodal_scoping(
+    #         [2, 3, 4], server=harmonic_simulation._model._server
+    #     )
+    #     op.connect(1, mesh_scoping)
+    #     field_ref = op.eval()[0]
+    #     assert field.component_count == 1
+    #     assert field.data.shape == (3,)
+    #     assert np.allclose(field.data, field_ref.data)
 
     def test_reaction_force(self, allkindofcomplexity):
         harmonic_simulation = post.load_simulation(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -469,6 +469,61 @@ class TestStaticMechanicalSimulation:
         assert field.data.shape == (9433, 3)
         assert np.allclose(field.data, field_ref.data)
 
+    def test_elastic_strain_eqv_von_mises(self, static_simulation):
+        result = static_simulation.elastic_strain_eqv_von_mises(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = static_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=static_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = static_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        field_ref = equivalent_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_nodal(self, static_simulation):
+        result = static_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = static_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=static_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = static_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = static_simulation._model.operator(name="to_nodal_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_elemental(self, static_simulation):
+        result = static_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = static_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=static_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = static_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = static_simulation._model.operator(name="to_elemental_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
 
 class TestTransientMechanicalSimulation:
     @fixture
@@ -956,6 +1011,63 @@ class TestTransientMechanicalSimulation:
         assert field.component_count == 3
         assert np.allclose(field.data, field_ref.data)
 
+    def test_elastic_strain_eqv_von_mises(self, transient_simulation):
+        result = transient_simulation.elastic_strain_eqv_von_mises(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = transient_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=transient_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = transient_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        field_ref = equivalent_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_nodal(self, transient_simulation):
+        result = transient_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = transient_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=transient_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = transient_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = transient_simulation._model.operator(name="to_nodal_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_elemental(self, transient_simulation):
+        result = transient_simulation.elastic_strain_eqv_von_mises_elemental(
+            set_ids=[1]
+        )
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = transient_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=transient_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = transient_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = transient_simulation._model.operator(name="to_elemental_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
 
 class TestModalMechanicalSimulation:
     @fixture
@@ -1294,6 +1406,61 @@ class TestModalMechanicalSimulation:
         principal_op = modal_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_3()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises(self, modal_simulation):
+        result = modal_simulation.elastic_strain_eqv_von_mises(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = modal_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=modal_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = modal_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        field_ref = equivalent_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_nodal(self, modal_simulation):
+        result = modal_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = modal_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=modal_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = modal_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = modal_simulation._model.operator(name="to_nodal_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_elemental(self, modal_simulation):
+        result = modal_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
+        assert len(result._fc) == 1
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = modal_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=modal_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = modal_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = modal_simulation._model.operator(name="to_elemental_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
 
@@ -1698,5 +1865,60 @@ class TestHarmonicMechanicalSimulation:
         principal_op = harmonic_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_3()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises(self, harmonic_simulation):
+        result = harmonic_simulation.elastic_strain_eqv_von_mises(set_ids=[1])
+        assert len(result._fc) == 2
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = harmonic_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=harmonic_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = harmonic_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        field_ref = equivalent_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_nodal(self, harmonic_simulation):
+        result = harmonic_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
+        assert len(result._fc) == 2
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = harmonic_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=harmonic_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = harmonic_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = harmonic_simulation._model.operator(name="to_nodal_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
+        assert field.component_count == 1
+        assert np.allclose(field.data, field_ref.data)
+
+    def test_elastic_strain_eqv_von_mises_elemental(self, harmonic_simulation):
+        result = harmonic_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
+        assert len(result._fc) == 2
+        assert result._fc.get_time_scoping().ids == [1]
+        field = result._fc[0]
+        op = harmonic_simulation._model.operator("EPEL")
+        time_scoping = core.time_freq_scoping_factory.scoping_by_set(
+            1, server=harmonic_simulation._model._server
+        )
+        op.connect(0, time_scoping)
+        op.connect(9, post.locations.elemental_nodal)
+        equivalent_op = harmonic_simulation._model.operator(name="eqv_fc")
+        equivalent_op.connect(0, op.outputs.fields_container)
+        average_op = harmonic_simulation._model.operator(name="to_elemental_fc")
+        average_op.connect(0, equivalent_op.outputs.fields_container)
+        field_ref = average_op.outputs.fields_container()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1428,7 +1428,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_nodal(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_nodal(set_ids=[1])
-        assert len(result._fc) == 1
+        assert len(result._fc) == 2
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")
@@ -1447,7 +1447,7 @@ class TestModalMechanicalSimulation:
 
     def test_elastic_strain_eqv_von_mises_elemental(self, modal_simulation):
         result = modal_simulation.elastic_strain_eqv_von_mises_elemental(set_ids=[1])
-        assert len(result._fc) == 1
+        assert len(result._fc) == 2
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("EPEL")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -3,13 +3,13 @@ import numpy as np
 import pytest
 from pytest import fixture
 
-import ansys.dpf.post as dpf
+from ansys.dpf import post
 from ansys.dpf.post.common import AvailableSimulationTypes
 
 
 @fixture
 def static_simulation(static_rst):
-    return dpf.load_simulation(
+    return post.load_simulation(
         data_sources=static_rst,
         simulation_type=AvailableSimulationTypes.static_mechanical,
     )
@@ -38,7 +38,7 @@ def test_simulation_loads(static_simulation):
 
 def test_simulation_mesh(static_simulation):
     mesh = static_simulation.mesh
-    assert isinstance(mesh, dpf.mesh.Mesh)
+    assert isinstance(mesh, post.mesh.Mesh)
 
 
 def test_simulation_named_selections(static_simulation):
@@ -49,7 +49,7 @@ def test_simulation_named_selections(static_simulation):
 
 def test_simulation_active_selection(static_simulation):
     assert static_simulation.active_selection is None
-    selection = dpf.selection.Selection()
+    selection = post.selection.Selection()
     static_simulation.activate_selection(selection=selection)
     assert static_simulation.active_selection == selection
     static_simulation.deactivate_selection()
@@ -202,7 +202,7 @@ class TestStaticMechanicalSimulation:
         assert stress_x._fc.get_time_scoping().ids == [1]
         field = stress_x._fc[0]
         op = static_simulation._model.operator("SX")
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (64,)
@@ -214,7 +214,7 @@ class TestStaticMechanicalSimulation:
         assert stress_x._fc.get_time_scoping().ids == [1]
         field = stress_x._fc[0]
         op = static_simulation._model.operator("SX")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (8,)
@@ -226,7 +226,7 @@ class TestStaticMechanicalSimulation:
         assert stress_x._fc.get_time_scoping().ids == [1]
         field = stress_x._fc[0]
         op = static_simulation._model.operator("SX")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (81,)
@@ -238,7 +238,7 @@ class TestStaticMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = static_simulation._model.operator("S1")
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (64,)
@@ -250,7 +250,7 @@ class TestStaticMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = static_simulation._model.operator("S2")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (81,)
@@ -262,7 +262,7 @@ class TestStaticMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = static_simulation._model.operator("S3")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (8,)
@@ -274,7 +274,7 @@ class TestStaticMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = static_simulation._model.operator("S_eqv")
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (64,)
@@ -286,7 +286,7 @@ class TestStaticMechanicalSimulation:
         assert stress_vm._fc.get_time_scoping().ids == [1]
         field = stress_vm._fc[0]
         op = static_simulation._model.operator("S_eqv")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (8,)
@@ -298,7 +298,7 @@ class TestStaticMechanicalSimulation:
         assert stress_vm._fc.get_time_scoping().ids == [1]
         field = stress_vm._fc[0]
         op = static_simulation._model.operator("S_eqv")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (81,)
@@ -388,7 +388,7 @@ class TestStaticMechanicalSimulation:
         assert structural_temperature_nodal._fc.get_time_scoping().ids == [1]
         field = structural_temperature_nodal._fc[0]
         op = static_simulation._model.operator("BFE")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (81,)
@@ -402,14 +402,14 @@ class TestStaticMechanicalSimulation:
         assert structural_temperature_elemental._fc.get_time_scoping().ids == [1]
         field = structural_temperature_elemental._fc[0]
         op = static_simulation._model.operator("BFE")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert field.data.shape == (12,)
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces(self, allkindofcomplexity):
-        static_simulation = dpf.load_simulation(data_sources=allkindofcomplexity)
+        static_simulation = post.load_simulation(data_sources=allkindofcomplexity)
         element_nodal_forces = static_simulation.element_nodal_forces()
         assert len(element_nodal_forces._fc) == 1
         assert element_nodal_forces._fc.get_time_scoping().ids == [1]
@@ -421,26 +421,26 @@ class TestStaticMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_nodal(self, allkindofcomplexity):
-        static_simulation = dpf.load_simulation(data_sources=allkindofcomplexity)
+        static_simulation = post.load_simulation(data_sources=allkindofcomplexity)
         element_nodal_forces = static_simulation.element_nodal_forces_nodal()
         assert len(element_nodal_forces._fc) == 3
         assert element_nodal_forces._fc.get_time_scoping().ids == [1]
         field = element_nodal_forces._fc[0]
         op = static_simulation._model.operator("ENF")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert field.data.shape == (14982, 3)
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_elemental(self, allkindofcomplexity):
-        static_simulation = dpf.load_simulation(data_sources=allkindofcomplexity)
+        static_simulation = post.load_simulation(data_sources=allkindofcomplexity)
         element_nodal_forces = static_simulation.element_nodal_forces_elemental()
         assert len(element_nodal_forces._fc) == 3
         assert element_nodal_forces._fc.get_time_scoping().ids == [1]
         field = element_nodal_forces._fc[0]
         op = static_simulation._model.operator("ENF")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert field.data.shape == (9433, 3)
@@ -450,7 +450,7 @@ class TestStaticMechanicalSimulation:
 class TestTransientMechanicalSimulation:
     @fixture
     def transient_simulation(self, plate_msup):
-        return dpf.load_simulation(
+        return post.load_simulation(
             data_sources=plate_msup,
             simulation_type=AvailableSimulationTypes.transient_mechanical,
         )
@@ -571,7 +571,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -586,7 +586,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -601,7 +601,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -616,7 +616,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -631,7 +631,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -648,7 +648,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -663,7 +663,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -678,7 +678,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -693,7 +693,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -708,7 +708,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -725,7 +725,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -740,7 +740,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -757,7 +757,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         principal_op = transient_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_1()[0]
@@ -776,7 +776,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         principal_op = transient_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_2()[0]
@@ -795,7 +795,7 @@ class TestTransientMechanicalSimulation:
             2, server=transient_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         principal_op = transient_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_3()[0]
@@ -803,7 +803,7 @@ class TestTransientMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_reaction_force(self, allkindofcomplexity):
-        transient_simulation = dpf.load_simulation(
+        transient_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.transient_mechanical,
         )
@@ -873,7 +873,7 @@ class TestTransientMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = transient_simulation._model.operator("BFE")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -884,13 +884,13 @@ class TestTransientMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
         op = transient_simulation._model.operator("BFE")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces(self, allkindofcomplexity):
-        transient_simulation = dpf.load_simulation(
+        transient_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.transient_mechanical,
         )
@@ -904,7 +904,7 @@ class TestTransientMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_nodal(self, allkindofcomplexity):
-        transient_simulation = dpf.load_simulation(
+        transient_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.transient_mechanical,
         )
@@ -913,13 +913,13 @@ class TestTransientMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = transient_simulation._model.operator("ENF")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_elemental(self, allkindofcomplexity):
-        transient_simulation = dpf.load_simulation(
+        transient_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.transient_mechanical,
         )
@@ -928,7 +928,7 @@ class TestTransientMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = transient_simulation._model.operator("ENF")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert np.allclose(field.data, field_ref.data)
@@ -937,7 +937,7 @@ class TestTransientMechanicalSimulation:
 class TestModalMechanicalSimulation:
     @fixture
     def modal_simulation(self, modalallkindofcomplexity):
-        return dpf.load_simulation(
+        return post.load_simulation(
             data_sources=modalallkindofcomplexity,
             simulation_type=AvailableSimulationTypes.modal_mechanical,
         )
@@ -971,7 +971,7 @@ class TestModalMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_reaction_force(self, allkindofcomplexity):
-        modal_simulation = dpf.load_simulation(
+        modal_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.modal_mechanical,
         )
@@ -985,7 +985,7 @@ class TestModalMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces(self, allkindofcomplexity):
-        modal_simulation = dpf.load_simulation(
+        modal_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.modal_mechanical,
         )
@@ -999,7 +999,7 @@ class TestModalMechanicalSimulation:
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_nodal(self, allkindofcomplexity):
-        modal_simulation = dpf.load_simulation(
+        modal_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.modal_mechanical,
         )
@@ -1008,13 +1008,13 @@ class TestModalMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("ENF")
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert np.allclose(field.data, field_ref.data)
 
     def test_element_nodal_forces_elemental(self, allkindofcomplexity):
-        modal_simulation = dpf.load_simulation(
+        modal_simulation = post.load_simulation(
             data_sources=allkindofcomplexity,
             simulation_type=AvailableSimulationTypes.modal_mechanical,
         )
@@ -1023,7 +1023,7 @@ class TestModalMechanicalSimulation:
         assert result._fc.get_time_scoping().ids == [1]
         field = result._fc[0]
         op = modal_simulation._model.operator("ENF")
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 3
         assert np.allclose(field.data, field_ref.data)
@@ -1038,7 +1038,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1053,7 +1053,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1068,7 +1068,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1083,7 +1083,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1098,7 +1098,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1113,7 +1113,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1128,7 +1128,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1143,7 +1143,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1158,7 +1158,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1184,7 +1184,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1199,7 +1199,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1214,7 +1214,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1229,7 +1229,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental_nodal)
+        op.connect(9, post.locations.elemental_nodal)
         principal_op = modal_simulation._model.operator(name="invariants_fc")
         principal_op.connect(0, op.outputs.fields_container)
         field_ref = principal_op.outputs.fields_eig_1()[0]
@@ -1248,7 +1248,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.nodal)
+        op.connect(9, post.locations.nodal)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1265,7 +1265,7 @@ class TestModalMechanicalSimulation:
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
-        op.connect(9, core.locations.elemental)
+        op.connect(9, post.locations.elemental)
         field_ref = op.eval()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
@@ -1274,7 +1274,7 @@ class TestModalMechanicalSimulation:
 class TestHarmonicMechanicalSimulation:
     @fixture
     def harmonic_simulation(self, complex_model):
-        return dpf.load_simulation(
+        return post.load_simulation(
             data_sources=complex_model,
             simulation_type=AvailableSimulationTypes.harmonic_mechanical,
         )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1266,13 +1266,15 @@ class TestModalMechanicalSimulation:
         assert len(result._fc) == 2
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
-        op = modal_simulation._model.operator("EPEL2")
+        op = modal_simulation._model.operator("EPEL")
         time_scoping = core.time_freq_scoping_factory.scoping_by_set(
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.nodal)
-        field_ref = op.eval()[0]
+        principal_op = modal_simulation._model.operator(name="invariants_fc")
+        principal_op.connect(0, op.outputs.fields_container)
+        field_ref = principal_op.outputs.fields_eig_2()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
 
@@ -1283,13 +1285,15 @@ class TestModalMechanicalSimulation:
         assert len(result._fc) == 2
         assert result._fc.get_time_scoping().ids == [2]
         field = result._fc[0]
-        op = modal_simulation._model.operator("EPEL3")
+        op = modal_simulation._model.operator("EPEL")
         time_scoping = core.time_freq_scoping_factory.scoping_by_set(
             2, server=modal_simulation._model._server
         )
         op.connect(0, time_scoping)
         op.connect(9, post.locations.elemental)
-        field_ref = op.eval()[0]
+        principal_op = modal_simulation._model.operator(name="invariants_fc")
+        principal_op.connect(0, op.outputs.fields_container)
+        field_ref = principal_op.outputs.fields_eig_3()[0]
         assert field.component_count == 1
         assert np.allclose(field.data, field_ref.data)
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -5,6 +5,10 @@ from pytest import fixture
 
 from ansys.dpf import post
 from ansys.dpf.post.common import AvailableSimulationTypes
+from ansys.dpf.post.harmonic_mechanical_simulation import HarmonicMechanicalSimulation
+from ansys.dpf.post.modal_mechanical_simulation import ModalMechanicalSimulation
+from ansys.dpf.post.static_mechanical_simulation import StaticMechanicalSimulation
+from ansys.dpf.post.transient_mechanical_simulation import TransientMechanicalSimulation
 
 
 @fixture
@@ -13,6 +17,17 @@ def static_simulation(static_rst):
         data_sources=static_rst,
         simulation_type=AvailableSimulationTypes.static_mechanical,
     )
+
+
+def test_simulation_init(static_rst):
+    simulation = StaticMechanicalSimulation(static_rst)
+    assert simulation is not None
+    simulation = TransientMechanicalSimulation(static_rst)
+    assert simulation is not None
+    simulation = ModalMechanicalSimulation(static_rst)
+    assert simulation is not None
+    simulation = HarmonicMechanicalSimulation(static_rst)
+    assert simulation is not None
 
 
 def test_simulation_results(static_simulation):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -102,6 +102,14 @@ class TestStaticMechanicalSimulation:
         with pytest.raises(ValueError, match="exclusive"):
             _ = static_simulation.displacement(load_steps=[1], set_ids=[1])
 
+    def test_raise_node_ids_elemental(self, static_simulation):
+        with pytest.raises(
+            ValueError, match="Argument 'node_ids' can only be used if 'location'"
+        ):
+            _ = static_simulation.stress(
+                node_ids=[42], location=post.locations.elemental
+            )
+
     def test_displacement(self, static_simulation):
         displacement_x = static_simulation.displacement(
             components=["X"], node_ids=[42, 43, 44]


### PR DESCRIPTION
Implement result extraction APIs for HarmonicMechanicalSimulation.

# HarmonicMechanicalSimulation methods

(checked: tested, italic: implemented)

- [x] _displacement_
- [x] _velocity_
- [x] _acceleration_
- [x] _stress, stress_elemental, stress_nodal_
- [x] _stress_principal, stress_principal_nodal, stress_principal_elemental__
- [x] _stress_eqv_von_mises, stress_eqv_von_mises_elemental, stress_eqv_von_mises_nodal_
- [x] _elastic_strain, elastic_strain_nodal, elastic_strain_elemental_
- [x] _elastic_strain_principal, elastic_strain_principal_nodal, elastic_strain_principal_elemental_
- [ ] _elastic_strain_eqv_von_mises, elastic_strain_eqv_von_mises_elemental, elastic_strain_eqv_von_mises_nodal_
- [ ] elastic_strain_energy_density
- [x] _reaction_force_
- [x] _element_nodal_forces, element_nodal_forces_nodal, element_nodal_forces_elemental_
- [ ] _nodal_force_
- [ ] _nodal_moment_
- [ ] _thickness_
- [ ] _element_centroids_
- [ ] _element_orientations_
- [ ] _elemental_mass_
- [x] _elemental_volume_