### PR TITLE
Fix iselect, update DataFrame.axes, Naming convention

### DIFF
--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -316,11 +316,15 @@ class DataFrame:
         """
         self._validate_arguments(arguments=kwargs)
         for label in kwargs.keys():
-            indices = kwargs[label]
             if label in self.index.names:
-                ids = getattr(self.index, label).values[indices]
+                values = getattr(self.index, label).values
             else:
-                ids = getattr(self.columns, label).values[indices]
+                values = getattr(self.columns, label).values
+            indices = kwargs[label]
+            if isinstance(indices, list):
+                ids = [values[i] for i in indices]
+            else:
+                ids = values[indices]
             if isinstance(ids, DPFArray):
                 ids = ids.tolist()
             kwargs[label] = ids

--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -683,7 +683,7 @@ class DataFrame:
 
     def animate(
         self,
-        save_as: Union[PathLike, None] = None,
+        save_as: Union[PathLike, str, None] = None,
         deform: bool = False,
         scale_factor: Union[List[float], float] = 1.0,
         **kwargs,
@@ -718,6 +718,8 @@ class DataFrame:
                         f"unable to animate on the deformed mesh:\n{e}"
                     )
                 )
+        else:
+            deform_by = False
         return self._fc.animate(
             save_as=save_as, deform_by=deform_by, scale_factor=scale_factor, **kwargs
         )

--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -19,10 +19,11 @@ from ansys.dpf.post.index import (
     MultiIndex,
     ResultsIndex,
     SetIndex,
+    ref_labels,
 )
 
-display_width = 80
-display_max_colwidth = 10
+display_width = 100
+display_max_colwidth = 12
 display_max_lines = 6
 
 
@@ -157,8 +158,8 @@ class DataFrame:
 
         """
         self._validate_arguments(arguments=kwargs)
-        if "set_id" in kwargs.keys():
-            kwargs["time"] = kwargs["set_id"]
+        if ref_labels.set_ids in kwargs.keys():
+            kwargs[ref_labels.time] = kwargs[ref_labels.set_ids]
         # Initiate a workflow
         server = self._fc._server
         wf = dpf.Workflow(server=server)
@@ -186,11 +187,15 @@ class DataFrame:
                 label_space = self._fc.get_label_space(i)
                 for fc_key in label_space.keys():
                     if fc_key in kwargs.keys() or (
-                        fc_key == "time" and "set_id" in kwargs.keys()
+                        fc_key == ref_labels.time
+                        and ref_labels.set_ids in kwargs.keys()
                     ):
                         key = fc_key
-                        if fc_key == "time" and "set_id" in kwargs.keys():
-                            key = "set_id"
+                        if (
+                            fc_key == ref_labels.time
+                            and ref_labels.set_ids in kwargs.keys()
+                        ):
+                            key = ref_labels.set_ids
                         if not isinstance(kwargs[key], list):
                             kwargs[key] = [kwargs[key]]
                         if label_space[fc_key] not in kwargs[key]:
@@ -199,10 +204,10 @@ class DataFrame:
             input_fc = fc
 
         # # Treat selection on components
-        if "comp" in kwargs.keys():
+        if ref_labels.components in kwargs.keys():
             from ansys.dpf.post.simulation import component_label_to_index
 
-            comp_to_extract = kwargs["comp"]
+            comp_to_extract = kwargs[ref_labels.components]
             if not isinstance(comp_to_extract, list):
                 comp_to_extract = [comp_to_extract]
             component_indexes = [component_label_to_index[c] for c in comp_to_extract]
@@ -223,7 +228,7 @@ class DataFrame:
             mesh_index_name in kwargs.keys()
             and mesh_index.location != locations.elemental_nodal
         ):
-            if "node" in mesh_index_name:
+            if ref_labels.node_ids in mesh_index_name:
                 node_ids = kwargs[mesh_index_name]
                 if not isinstance(node_ids, (DPFArray, list)):
                     node_ids = [node_ids]
@@ -231,7 +236,7 @@ class DataFrame:
                     node_ids=node_ids,
                     server=server,
                 )
-            elif "element" in mesh_index_name:
+            elif ref_labels.element_ids in mesh_index_name:
                 element_ids = kwargs[mesh_index_name]
                 if not isinstance(element_ids, list):
                     element_ids = [element_ids]
@@ -473,8 +478,8 @@ class DataFrame:
             label_space = {}
             for label_name in self.labels:
                 value = combination[label_positions_in_combinations[label_name]]
-                if label_name == "set_id":
-                    label_name = "time"
+                if label_name == ref_labels.set_ids:
+                    label_name = ref_labels.time
                 label_space[label_name] = value
             fields = self._fc.get_fields(label_space=label_space)
             values = []

--- a/src/ansys/dpf/post/index.py
+++ b/src/ansys/dpf/post/index.py
@@ -7,13 +7,30 @@ import ansys.dpf.core as dpf
 
 from ansys.dpf import post
 
+
+class ref_labels:
+    """Reference naming for different common Indexes."""
+
+    components = "components"
+    results = "results"
+    time = "time"
+    modes = "modes"
+    frequencies = "frequencies"
+    set_ids = "set_ids"
+    node_ids = "node_ids"
+    element_ids = "element_ids"
+    elemental_nodal = "element_ids"
+    step = "step_ids"
+    overall = "overall"
+
+
 location_to_label = {
-    dpf.locations.nodal: "node",
-    dpf.locations.elemental: "element",
-    dpf.locations.elemental_nodal: "element",
-    dpf.locations.overall: "overall",
-    dpf.locations.time_freq_step: "step",
-    dpf.locations.time_freq: "set",
+    dpf.locations.nodal: ref_labels.node_ids,
+    dpf.locations.elemental: ref_labels.element_ids,
+    dpf.locations.elemental_nodal: ref_labels.elemental_nodal,
+    dpf.locations.overall: ref_labels.overall,
+    dpf.locations.time_freq_step: ref_labels.step,
+    dpf.locations.time_freq: ref_labels.set_ids,
 }
 
 
@@ -145,7 +162,7 @@ class ResultsIndex(Index):
         values: List[str],
     ):
         """Initiate this class."""
-        super().__init__(name="results", values=values, scoping=None)
+        super().__init__(name=ref_labels.results, values=values, scoping=None)
 
     def __repr__(self):
         """Representation of the Index."""
@@ -178,7 +195,7 @@ class TimeIndex(Index):
         scoping: Union[dpf.Scoping, None] = None,
     ):
         """Initiate this class."""
-        super().__init__(name="time", values=values, scoping=scoping)
+        super().__init__(name=ref_labels.time, values=values, scoping=scoping)
 
     def __repr__(self):
         """Representation of the Index."""
@@ -194,7 +211,7 @@ class ModeIndex(Index):
         scoping: Union[dpf.Scoping, None] = None,
     ):
         """Initiate this class."""
-        super().__init__(name="mode", values=values, scoping=scoping)
+        super().__init__(name=ref_labels.modes, values=values, scoping=scoping)
 
     def __repr__(self):
         """Representation of the Index."""
@@ -210,7 +227,7 @@ class FrequencyIndex(Index):
         scoping: Union[dpf.Scoping, None] = None,
     ):
         """Initiate this class."""
-        super().__init__(name="frequency", values=values, scoping=scoping)
+        super().__init__(name=ref_labels.frequencies, values=values, scoping=scoping)
 
     def __repr__(self):
         """Representation of the Index."""
@@ -218,7 +235,7 @@ class FrequencyIndex(Index):
 
 
 class SetIndex(LabelIndex):
-    """Index class specific to set_id."""
+    """Index class specific to set_ids."""
 
     def __init__(
         self,
@@ -226,7 +243,7 @@ class SetIndex(LabelIndex):
         scoping: Union[dpf.Scoping, None] = None,
     ):
         """Initiate this class."""
-        super().__init__(name="set_id", values=values, scoping=scoping)
+        super().__init__(name=ref_labels.set_ids, values=values, scoping=scoping)
 
     def __repr__(self):
         """Representation of the Index."""
@@ -241,7 +258,7 @@ class CompIndex(Index):
         values: Union[List, None] = None,
     ):
         """Initiate this class."""
-        super().__init__(name="comp", values=values)
+        super().__init__(name=ref_labels.components, values=values)
 
 
 class MultiIndex:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -108,11 +108,11 @@ def test_dataframe_select(df):
 
 
 def test_dataframe_iselect(df):
-    df2 = df.iselect(node_ids=[0, 1], set_ids=0, components=0)
+    df2 = df.iselect(node_ids=[0, 1], set_ids=[0], components=0)
     assert all(df2.mesh_index.values == [1, 26])
     assert df2.index.components.values == ["X"]
     assert df2.columns.set_ids.values == [1]
-    # print(df2)
+    print(df2)
 
 
 def test_dataframe_plot(df):

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -117,6 +117,18 @@ def test_dataframe_plot(df):
     df.plot(set_id=1, node=[1, 2, 3, 4, 5, 6, 7, 8, 9])
 
 
+def test_dataframe_animate(transient_rst):
+    simulation = TransientMechanicalSimulation(transient_rst)
+    # Animate displacement
+    df = simulation.displacement(all_sets=True)
+    # df.animate()
+    df.animate(scale_factor=5.0, deform=True, save_as="test_dataframe_animate.gif")
+    # Animate nodal stress -> Does not work
+    df2 = simulation.stress_nodal(all_sets=True)
+    # df2.animate()
+    # assert False
+
+
 def test_dataframe_repr(df):
     ref = (
         "DataFrame<index=MultiIndex<[MeshIndex<name=\"node\", dtype=<class 'int'>>, "

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -52,7 +52,8 @@ def test_dataframe_from_fields_container(simple_bar):
         columns=column_index,
         index=row_index,
     )
-    assert df.axes == ["node", "comp", "time", "results"]
+    assert df.index.names == ["node", "comp"]
+    assert df.columns.names == ["time", "results"]
 
 
 def test_dataframe_from_error():

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -9,6 +9,7 @@ from ansys.dpf.post.index import (
     MeshIndex,
     MultiIndex,
     ResultsIndex,
+    ref_labels,
 )
 from ansys.dpf.post.static_mechanical_simulation import StaticMechanicalSimulation
 from ansys.dpf.post.transient_mechanical_simulation import TransientMechanicalSimulation
@@ -52,8 +53,8 @@ def test_dataframe_from_fields_container(simple_bar):
         columns=column_index,
         index=row_index,
     )
-    assert df.index.names == ["node", "comp"]
-    assert df.columns.names == ["time", "results"]
+    assert df.index.names == [ref_labels.node_ids, ref_labels.components]
+    assert df.columns.names == [ref_labels.time, ref_labels.results]
 
 
 def test_dataframe_from_error():
@@ -94,28 +95,28 @@ def test_dataframe_select_raise(df, transient_rst):
     with pytest.raises(NotImplementedError, match="Element selection"):
         simulation = TransientMechanicalSimulation(transient_rst)
         df = simulation.stress()
-        _ = df.select(element=391)
+        _ = df.select(element_ids=391)
 
 
 def test_dataframe_select(df):
     # print(df)
-    df2 = df.select(node=[1, 2], set_id=1, comp="X")
+    df2 = df.select(node_ids=[1, 2], set_ids=1, components="X")
     assert all(df2.mesh_index.values == [1, 2])
-    assert df2.index.comp.values == ["X"]
-    assert df2.columns.set_id.values == [1]
+    assert df2.index.components.values == ["X"]
+    assert df2.columns.set_ids.values == [1]
     # print(df2)
 
 
 def test_dataframe_iselect(df):
-    df2 = df.iselect(node=[0, 1], set_id=0, comp=0)
+    df2 = df.iselect(node_ids=[0, 1], set_ids=0, components=0)
     assert all(df2.mesh_index.values == [1, 26])
-    assert df2.index.comp.values == ["X"]
-    assert df2.columns.set_id.values == [1]
+    assert df2.index.components.values == ["X"]
+    assert df2.columns.set_ids.values == [1]
     # print(df2)
 
 
 def test_dataframe_plot(df):
-    df.plot(set_id=1, node=[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    df.plot(set_ids=1, node_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9])
 
 
 def test_dataframe_animate(transient_rst):
@@ -132,8 +133,8 @@ def test_dataframe_animate(transient_rst):
 
 def test_dataframe_repr(df):
     ref = (
-        "DataFrame<index=MultiIndex<[MeshIndex<name=\"node\", dtype=<class 'int'>>, "
-        "Index<name=\"comp\", dtype=<class 'str'>>]>, columns=MultiIndex<[ResultIndex<['U']>, "
+        "DataFrame<index=MultiIndex<[MeshIndex<name=\"node_ids\", dtype=<class 'int'>>, "
+        "Index<name=\"components\", dtype=<class 'str'>>]>, columns=MultiIndex<[ResultIndex<['U']>, "  # noqa: E501
         "SetIndex<values=[1]>]>>"
     )
     assert repr(df) == ref
@@ -144,72 +145,72 @@ def test_dataframe_str(transient_rst):
     df = simulation.displacement(all_sets=True)
     print(df)
     ref = """
-             results         U                                                         ...
-              set_id         1         2         3         4         5         6       ...
-      node      comp                                                                   ...
-       525         X  0.00e+00  4.85e-05  2.30e-04  6.51e-04  1.48e-03  2.93e-03       ...
-                   Y  0.00e+00  2.87e-04  1.14e-03  2.54e-03  4.41e-03  6.59e-03       ...
-                   Z  0.00e+00 -1.26e-10 -4.34e-10 -8.29e-10 -1.15e-09 -1.39e-09       ...
-       534         X  0.00e+00  6.55e-06  1.05e-04  5.30e-04  1.67e-03  4.02e-03       ...
-                   Y  0.00e+00  6.27e-04  2.51e-03  5.62e-03  9.86e-03  1.50e-02       ...
-                   Z  0.00e+00 -3.20e-10 -1.10e-09 -2.13e-09 -2.94e-09 -3.57e-09       ...
-       ...
-"""  # noqa: W291
+                 results           U                                                                     ...
+                 set_ids           1           2           3           4           5           6         ...
+    node_ids  components                                                                                 ...
+         525           X  0.0000e+00  4.8506e-05  2.3022e-04  6.5140e-04  1.4812e-03  2.9324e-03         ...
+                       Y  0.0000e+00  2.8732e-04  1.1437e-03  2.5408e-03  4.4069e-03  6.5936e-03         ...
+                       Z  0.0000e+00 -1.2615e-10 -4.3450e-10 -8.2924e-10 -1.1459e-09 -1.3910e-09         ...
+         534           X  0.0000e+00  6.5467e-06  1.0495e-04  5.3050e-04  1.6666e-03  4.0153e-03         ...
+                       Y  0.0000e+00  6.2670e-04  2.5072e-03  5.6168e-03  9.8601e-03  1.4993e-02         ...
+                       Z  0.0000e+00 -3.1963e-10 -1.1039e-09 -2.1288e-09 -2.9359e-09 -3.5675e-09         ...
+         ...
+"""  # noqa: W291, E501
     assert str(df) == ref
-    df2 = df.select(node=525)
+    df2 = df.select(node_ids=525)
     print(df2)
     ref = """
-             results         U                                                         ...
-              set_id         1         2         3         4         5         6       ...
-      node      comp                                                                   ...
-       525         X  0.00e+00  4.85e-05  2.30e-04  6.51e-04  1.48e-03  2.93e-03       ...
-                   Y  0.00e+00  2.87e-04  1.14e-03  2.54e-03  4.41e-03  6.59e-03       ...
-                   Z  0.00e+00 -1.26e-10 -4.34e-10 -8.29e-10 -1.15e-09 -1.39e-09       ...
-"""  # noqa: W291
+                 results           U                                                                     ...
+                 set_ids           1           2           3           4           5           6         ...
+    node_ids  components                                                                                 ...
+         525           X  0.0000e+00  4.8506e-05  2.3022e-04  6.5140e-04  1.4812e-03  2.9324e-03         ...
+                       Y  0.0000e+00  2.8732e-04  1.1437e-03  2.5408e-03  4.4069e-03  6.5936e-03         ...
+                       Z  0.0000e+00 -1.2615e-10 -4.3450e-10 -8.2924e-10 -1.1459e-09 -1.3910e-09         ...
+"""  # noqa: W291, E501
     assert str(df2) == ref
 
     df = simulation.stress()
     print(df)
     print(df._fc[0].get_entity_data_by_id(391))    
     ref = """
-             results         S
-              set_id        35
-   element      comp          
-       391    XX (1) -3.28e+05
-              YY (1)  1.36e+06
-              ZZ (1)  1.49e+08
-              XY (1) -4.89e+06
-              YZ (1)  1.43e+07
-              XZ (1)  1.65e+07
-       ...
-"""  # noqa: W291
+                 results           S
+                 set_ids          35
+ element_ids  components            
+         391      XX (1) -3.2780e+05
+                  YY (1)  1.3601e+06
+                  ZZ (1)  1.4909e+08
+                  XY (1) -4.8869e+06
+                  YZ (1)  1.4304e+07
+                  XZ (1)  1.6546e+07
+         ...
+"""  # noqa: W291, E501
     assert str(df) == ref
-    df2 = df.select(comp="YY")
+    df2 = df.select(components="YY")
     print(df2)
     ref = """
-             results         S
-              set_id        35
-   element      comp          
-       391    YY (1)  1.36e+06
-       391    YY (2)  1.29e+06
-       391    YY (3) -3.53e+07
-       391    YY (4) -2.72e+07
-       391    YY (5)  2.83e+07
-       391    YY (6)  5.26e+06
-       ...
-"""  # noqa: W291
+                 results           S
+                 set_ids          35
+ element_ids  components            
+         391      YY (1)  1.3601e+06
+         391      YY (2)  1.2931e+06
+         391      YY (3) -3.5347e+07
+         391      YY (4) -2.7237e+07
+         391      YY (5)  2.8319e+07
+         391      YY (6)  5.2558e+06
+         ...
+"""  # noqa: W291, E501
     assert str(df2) == ref
 
 
 def test_dataframe_str_comp(df):
     # 3D str
     stri = str(df)
-    expected_strs = ["X", "Y", "Z", "results", "U", "node"]
+    expected_strs = ["X", "Y", "Z", ref_labels.results, "U", ref_labels.node_ids]
     for expected_str in expected_strs:
         assert expected_str in stri
     # 1D str
-    stri = str(df.select(comp="X"))
-    expected_strs = ["X", "results", "U", "node"]
+    stri = str(df.select(components="X"))
+    expected_strs = ["X", ref_labels.results, "U", ref_labels.node_ids]
     for expected_str in expected_strs:
         assert expected_str in stri
     assert "Y" not in stri
@@ -218,12 +219,12 @@ def test_dataframe_str_comp(df):
 def test_dataframe_str_tensor(elastic_strain_df):
     # 3D str
     stri = str(elastic_strain_df)
-    expected_strs = ["XX", "XY", "XZ", "results", "EPEL", "node"]
+    expected_strs = ["XX", "XY", "XZ", ref_labels.results, "EPEL", ref_labels.node_ids]
     for expected_str in expected_strs:
         assert expected_str in stri
     # 1D str
-    stri = str(elastic_strain_df.select(comp=["XX", "XY"]))
-    expected_strs = ["XX", "XY", "results", "EPEL", "node"]
+    stri = str(elastic_strain_df.select(components=["XX", "XY"]))
+    expected_strs = ["XX", "XY", ref_labels.results, "EPEL", ref_labels.node_ids]
     for expected_str in expected_strs:
         assert expected_str in stri
     assert "ZZ" not in stri


### PR DESCRIPTION
- DataFrame.axes now returns [DataFrame.index, DataFrame.columns], the two MultiIndex objects, like in Pandas.
- Fix bug for iselect when selecting on a label with a list of indices.
- Make naming coherent between result query API arguments and DataFrame indexes default names. Increase default width of columns for printed DataFrame.