### PR TITLE
Add an associated displacement workflow to a DataFrame

### DIFF
--- a/src/ansys/dpf/post/__init__.py
+++ b/src/ansys/dpf/post/__init__.py
@@ -14,7 +14,7 @@ Examples
 """
 
 import ansys.dpf.core as core
-from ansys.dpf.core.common import locations  # noqa: F401
+from ansys.dpf.core.common import locations, shell_layers  # noqa: F401
 
 try:
     import importlib.metadata as importlib_metadata

--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -72,8 +72,8 @@ class DataFrame:
         self._last_display_max_colwidth = display_max_colwidth
 
     @property
-    def columns(self):
-        """Returns the column labels of the DataFrame."""
+    def columns(self) -> MultiIndex:
+        """Returns the MultiIndex for the columns of the DataFrame."""
         if self._columns is None:
             indexes = [ResultsIndex(values=[self._fc[0].name.split("_")])]
             indexes.extend(
@@ -86,8 +86,8 @@ class DataFrame:
         return self._columns
 
     @property
-    def index(self) -> Union[MultiIndex, Index]:
-        """Returns the Index or MultiIndex for the rows of the DataFrame."""
+    def index(self) -> MultiIndex:
+        """Returns the MultiIndex for the rows of the DataFrame."""
         return self._index
 
     @property

--- a/src/ansys/dpf/post/dataframe.py
+++ b/src/ansys/dpf/post/dataframe.py
@@ -694,7 +694,11 @@ class DataFrame:
         shell_layer: shell_layers = shell_layers.top,
         **kwargs,
     ):
-        """Animate the result.
+        """Animate the DataFrame along its 'set' axis.
+
+        .. note::
+            At the moment only useful to produce a temporal animation. Each frame will correspond
+            to data for a value of the SetIndex in the columns MultiIndex.
 
         Parameters
         ----------

--- a/src/ansys/dpf/post/harmonic_mechanical_simulation.py
+++ b/src/ansys/dpf/post/harmonic_mechanical_simulation.py
@@ -270,6 +270,8 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         # Evaluate  the workflow
         fc = wf.get_output("out", core.types.fields_container)
 
+        disp_wf = self._generate_disp_workflow(fc, selection)
+
         # Test for empty results
         if (len(fc) == 0) or all([len(f) == 0 for f in fc]):
             warnings.warn(
@@ -301,11 +303,13 @@ class HarmonicMechanicalSimulation(MechanicalSimulation):
         )
 
         # Return the result wrapped in a DPF_Dataframe
-        return DataFrame(
+        df = DataFrame(
             data=fc,
             columns=column_index,
             index=row_index,
         )
+        df._disp_wf = disp_wf
+        return df
 
     def displacement(
         self,

--- a/src/ansys/dpf/post/modal_mechanical_simulation.py
+++ b/src/ansys/dpf/post/modal_mechanical_simulation.py
@@ -212,7 +212,9 @@ class ModalMechanicalSimulation(MechanicalSimulation):
         # Evaluate  the workflow
         fc = wf.get_output("out", core.types.fields_container)
 
-        return self._create_dataframe(fc, location, columns, comp, base_name)
+        disp_wf = self._generate_disp_workflow(fc, selection)
+
+        return self._create_dataframe(fc, location, columns, comp, base_name, disp_wf)
 
     def displacement(
         self,

--- a/src/ansys/dpf/post/static_mechanical_simulation.py
+++ b/src/ansys/dpf/post/static_mechanical_simulation.py
@@ -208,7 +208,9 @@ class StaticMechanicalSimulation(MechanicalSimulation):
         # Evaluate  the workflow
         fc = wf.get_output("out", core.types.fields_container)
 
-        return self._create_dataframe(fc, location, columns, comp, base_name)
+        disp_wf = self._generate_disp_workflow(fc, selection)
+
+        return self._create_dataframe(fc, location, columns, comp, base_name, disp_wf)
 
     def displacement(
         self,

--- a/src/ansys/dpf/post/transient_mechanical_simulation.py
+++ b/src/ansys/dpf/post/transient_mechanical_simulation.py
@@ -1,7 +1,7 @@
 """Module containing the ``TransientMechanicalSimulation`` class."""
 from typing import List, Tuple, Union
 
-from ansys.dpf import core
+from ansys.dpf import core as dpf
 from ansys.dpf.post import locations
 from ansys.dpf.post.dataframe import DataFrame
 from ansys.dpf.post.selection import Selection
@@ -114,7 +114,7 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         )
 
         # Initialize a workflow
-        wf = core.Workflow(server=self._model._server)
+        wf = dpf.Workflow(server=self._model._server)
         wf.progress_bar = False
 
         if category == ResultCategory.equivalent and base_name[0] == "E":
@@ -218,9 +218,11 @@ class TransientMechanicalSimulation(MechanicalSimulation):
         # Set the workflow output
         wf.set_output_name("out", out)
         # Evaluate  the workflow
-        fc = wf.get_output("out", core.types.fields_container)
+        fc = wf.get_output("out", dpf.types.fields_container)
 
-        return self._create_dataframe(fc, location, columns, comp, base_name)
+        disp_wf = self._generate_disp_workflow(fc, selection)
+
+        return self._create_dataframe(fc, location, columns, comp, base_name, disp_wf)
 
     def displacement(
         self,

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -123,12 +123,11 @@ def test_dataframe_animate(transient_rst):
     simulation = TransientMechanicalSimulation(transient_rst)
     # Animate displacement
     df = simulation.displacement(all_sets=True)
-    # df.animate()
-    df.animate(scale_factor=5.0, deform=True, save_as="test_dataframe_animate.gif")
-    # Animate nodal stress -> Does not work
-    df2 = simulation.stress_nodal(all_sets=True)
-    # df2.animate()
-    # assert False
+    df.animate()
+    df.animate(scale_factor=5.0, deform=True)
+
+    df = simulation.stress_nodal(all_sets=True)
+    df.animate(deform=True, scale_factor=5.0)
 
 
 def test_dataframe_repr(df):


### PR DESCRIPTION
For animations on a deformed mesh.
A DataFrame holds a reference to a displacement query workflow to get displacement fields for updated coordinates whenever necessary. The ouptut of this workflow is passed to the Plotter as a deform_by argument.