### PR TITLE
Fix calls to doc-deploy-dev/stable pyansys actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,5 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: HTML-doc-ansys-dpf-post
+          decompress-artifact: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -198,12 +198,6 @@ jobs:
           path: HTML-doc-${{env.PACKAGE_NAME}}.zip
         if: always()
 
-      - name: "Upload HTML Documentation"
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-html
-          path: docs/build/html
-
       - name: "Find PDF Documentation"
         shell: bash
         if: ${{ inputs.generate_pdf == 'true' }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -41,13 +41,10 @@ jobs:
           file: HTML-doc-ansys-dpf-post.zip
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Unzip the HMTL documentation"
-        uses: montudor/action-zip@v1
-        with:
-          args: unzip -qq HTML-doc-ansys-dpf-post.zip -d documentation-html
-
       - name: Deploy the stable documentation
         uses: pyansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: HTML-doc-ansys-dpf-post
+          decompress-artifact: true


### PR DESCRIPTION
The previous implementation relied on a unzip step with renaming, unsing montudor/zip GitHub action.
However there is a known issue with the rights of the files once unzipped.
Furthermore, thanks to the v4 pyansys actions, this step is not even required.